### PR TITLE
Re-implementation of sampler_t type.

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -5999,7 +5999,7 @@ def err_static_kernel : Error<
 def err_static_function_scope : Error<
   "variables in function scope cannot be declared static">;
 def err_sampler_initializer_not_integer : Error<
-  "sampler_t initialization requires integer, not %0">;
+  "sampler_t initialization requires 32-bit integer, not %0">;
 def err_sampler_initializer_not_constant : Error<
   "sampler_t initialization requires compile time constant">;
 def err_sampler_argument_required : Error<

--- a/lib/CodeGen/CGDecl.cpp
+++ b/lib/CodeGen/CGDecl.cpp
@@ -809,7 +809,7 @@ CodeGenFunction::EmitAutoVarAlloca(const VarDecl &D) {
       // reference or bitfield members, and a few other cases, and checking
       // for POD-ness protects us from some of these.
       if (D.getInit() &&
-          (Ty->isArrayType() || Ty->isRecordType()) &&
+          (Ty->isArrayType() || Ty->isRecordType() || Ty->isSamplerT()) &&
           (Ty.isPODType(getContext()) ||
            getContext().getBaseElementType(Ty)->isObjCObjectPointerType()) &&
           D.getInit()->isConstantInitializer(getContext(), false)) {

--- a/lib/CodeGen/CGExprAgg.cpp
+++ b/lib/CodeGen/CGExprAgg.cpp
@@ -603,7 +603,15 @@ void AggExprEmitter::VisitCastExpr(CastExpr *E) {
            "Implicit cast types must be compatible");
     Visit(E->getSubExpr());
     break;
-      
+  case CK_IntToOCLSampler: {
+    const Expr *SE = cast<CastExpr>(E)->getSubExpr();
+    llvm::APSInt samplerValue;
+    bool IsInt = SE->EvaluateAsInt(samplerValue, CGF.CGM.getContext());
+    assert(IsInt && "expected 32-bit unsigned integer constant");
+    llvm::Value *data = Builder.CreateConstInBoundsGEP2_32(Dest.getAddr(), 0, 0);
+    Builder.CreateStore(Builder.getInt(samplerValue), data);
+    break;
+  }
   case CK_LValueBitCast:
     llvm_unreachable("should not be emitting lvalue bitcast as rvalue");
 
@@ -649,7 +657,6 @@ void AggExprEmitter::VisitCastExpr(CastExpr *E) {
   case CK_CopyAndAutoreleaseBlockObject:
   case CK_BuiltinFnToFnPtr:
   case CK_NullToOCLEvent:
-  case CK_IntToOCLSampler:
     llvm_unreachable("cast kind invalid for aggregate types");
   }
 }

--- a/lib/CodeGen/CGExprConstant.cpp
+++ b/lib/CodeGen/CGExprConstant.cpp
@@ -687,8 +687,16 @@ public:
     case CK_AtomicToNonAtomic:
     case CK_NonAtomicToAtomic:
     case CK_NoOp:
-    case CK_IntToOCLSampler:
       return C;
+
+    case CK_IntToOCLSampler: {
+      llvm::StructType* STy = CGM.getModule().getTypeByName("opencl.sampler_t");
+      if (STy == 0) {
+        STy = llvm::StructType::create(CGM.getLLVMContext(), C->getType(),
+                                       "opencl.sampler_t");
+      }
+      return llvm::ConstantStruct::get(STy, C);
+    }
 
     case CK_Dependent: llvm_unreachable("saw dependent cast!");
 

--- a/lib/CodeGen/CGOpenCLRuntime.cpp
+++ b/lib/CodeGen/CGOpenCLRuntime.cpp
@@ -75,7 +75,10 @@ llvm::Type *CGOpenCLRuntime::convertOpenCLSpecificType(const Type *T) {
     return llvm::PointerType::get(llvm::StructType::create(
                            CGM.getLLVMContext(), "opencl.image3d_t"), GlobalAS);
   case BuiltinType::OCLSampler:
-    return llvm::IntegerType::get(CGM.getLLVMContext(),32);
+    return llvm::StructType::create(
+                           CGM.getLLVMContext(),
+                           llvm::IntegerType::get(CGM.getLLVMContext(), 32),
+                           "opencl.sampler_t");
   case BuiltinType::OCLEvent:
     return llvm::PointerType::get(llvm::StructType::create(
                            CGM.getLLVMContext(), "opencl.event_t"), 0);

--- a/lib/CodeGen/CodeGenFunction.cpp
+++ b/lib/CodeGen/CodeGenFunction.cpp
@@ -72,6 +72,7 @@ llvm::Type *CodeGenFunction::ConvertType(QualType T) {
 }
 
 bool CodeGenFunction::hasAggregateLLVMType(QualType type) {
+  if(type.getCanonicalType()->isSamplerT()) return true;
   switch (type.getCanonicalType()->getTypeClass()) {
 #define TYPE(name, parent)
 #define ABSTRACT_TYPE(name, parent)

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -2029,6 +2029,11 @@ void CastOperation::CheckCStyleCast() {
       return;
     }
 
+    if(SrcType->isIntegerType() && DestType->isSamplerT()) {
+      Kind = CK_IntToOCLSampler;
+      return;
+    }
+
     // Reject any other conversions to non-scalar types.
     Self.Diag(OpRange.getBegin(), diag::err_typecheck_cond_expect_scalar)
       << DestType << SrcExpr.get()->getSourceRange();

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -5919,6 +5919,11 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
     }
   }
 
+  if (LHSType->isSamplerT() && RHSType->isIntegerType()) {
+    Kind = CK_IntToOCLSampler;
+    return Compatible;
+  }
+
   return Incompatible;
 }
 

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -3993,8 +3993,7 @@ static bool TryOCLSamplerInitialization(Sema &S,
                                         InitializationSequence &Sequence,
                                         QualType DestType,
                                         Expr *Initializer) {
-  if (!S.getLangOpts().OpenCL || !DestType->isSamplerT() ||
-    !Initializer->isIntegerConstantExpr(S.getASTContext()))
+  if (!S.getLangOpts().OpenCL || !DestType->isSamplerT())
     return false;
 
   Sequence.AddOCLSamplerInitStep(DestType);
@@ -5463,19 +5462,27 @@ InitializationSequence::Perform(Sema &S,
       bool isConst = CurInit.get()->isConstantInitializer(S.Context, false);
       InitializedEntity::EntityKind EntityKind = Entity.getKind();
 
-      if (EntityKind == InitializedEntity::EK_Variable ||
-          EntityKind == InitializedEntity::EK_Parameter) {
+      if (SourceType->isSamplerT() && DestType->isSamplerT()) {
+        // copy-assignment or copy-initialization
+      }
+      else if (EntityKind == InitializedEntity::EK_Variable ||
+               EntityKind == InitializedEntity::EK_Parameter) {
         if (!isConst)
           S.Diag(Kind.getLocation(), diag::err_sampler_initializer_not_constant);
-        else if (!SourceType->isIntegerType())
+        if (!SourceType->isIntegerType() ||
+            32 != S.Context.getIntWidth(SourceType))
           S.Diag(Kind.getLocation(), diag::err_sampler_initializer_not_integer)
             << SourceType;
       } else
         llvm_unreachable("Invalid EntityKind!");
 
-      CurInit = S.ImpCastExprToType(CurInit.take(), Step->Type,
-                                    CK_IntToOCLSampler,
-                                    CurInit.get()->getValueKind());
+      ExprResult Result = CurInit;
+      Sema::AssignConvertType ConvTy =
+        S.CheckSingleAssignmentConstraints(Step->Type, Result, true/*,
+            Entity.getKind() == InitializedEntity::EK_Parameter_CF_Audited*/);
+      if (Result.isInvalid())
+        return ExprError();
+      CurInit = Result;
       break;
     }
     case SK_OCLNULLEvent: {

--- a/test/CodeGenOpenCL/sampler_t.cl
+++ b/test/CodeGenOpenCL/sampler_t.cl
@@ -1,0 +1,68 @@
+// RUN: %clang_cc1 %s -triple spir-unknown-unknown -emit-llvm -o - -O0 | FileCheck %s
+
+// CHECK: %opencl.sampler_t = type { i32 }
+
+#define CLK_NORMALIZED_COORDS_TRUE 0x01
+#define CLK_ADDRESS_REPEAT 0x02
+#define CLK_FILTER_NEAREST 0x04
+
+const sampler_t gs = 2;
+// CHECK: @gs = constant %opencl.sampler_t { i32 2 }, align 4
+
+constant sampler_t cgs = 3;
+// CHECK: @cgs = addrspace(2) {{[a-z]+}} %opencl.sampler_t { i32 3 }, align 4
+
+// CHECK: @bar.kst = internal constant %opencl.sampler_t { i32 5 }, align 4
+// CHECK: @bar.cst = internal addrspace(2) {{[a-z]+}} %opencl.sampler_t { i32 6 }, align 4
+// CHECK: @bar.lst = internal constant %opencl.sampler_t { i32 7 }, align 4
+// CHECK: @bar.dd = internal addrspace(2) {{[a-z]+}} %opencl.sampler_t { i32 3 }, align 4
+
+
+void foo(const sampler_t st){}
+// CHECK: define cc75 void @foo(%opencl.sampler_t* byval %st)
+
+kernel void bar(const sampler_t ast) {
+// CHECK: define cc76 void @bar(%opencl.sampler_t* byval %ast)
+
+// CHECK: %ost = alloca %opencl.sampler_t, align 4
+// CHECK: [[Q_SAMPLER:%.*]] = alloca %opencl.sampler_t, align 4
+// CHECK: [[LITERAL_ARG:%.*]] = alloca %opencl.sampler_t, align 4
+// CHECK: [[DD_SAMPLER:%.*]] = alloca %opencl.sampler_t, align 4
+// CHECK: [[LITERAL_ARG2:%.*]] = alloca %opencl.sampler_t, align 4
+
+    const sampler_t kst = 5;
+    foo(kst);
+// CHECK: call cc75 void @foo(%opencl.sampler_t* byval @bar.kst)
+
+    constant sampler_t cst = 6;
+    const sampler_t ost = cst;
+// CHECK: [[OST:%.*]] = bitcast %opencl.sampler_t* %ost to i8*
+// CHECK: call void @llvm.memcpy.p0i8.p2i8.i32(i8* [[OST]], i8 addrspace(2)* bitcast (%opencl.sampler_t addrspace(2)* @bar.cst to i8 addrspace(2)*), i32 4, i32 4, i1 false)
+
+    const sampler_t lst = CLK_NORMALIZED_COORDS_TRUE|CLK_ADDRESS_REPEAT|CLK_FILTER_NEAREST;
+    foo(lst);
+// CHECK: call cc75 void @foo(%opencl.sampler_t* byval @bar.lst)
+
+    const int q = CLK_NORMALIZED_COORDS_TRUE|CLK_ADDRESS_REPEAT;
+    foo(q);
+// CHECK: [[Q_PTR:%.*]] = getelementptr inbounds %opencl.sampler_t* [[Q_SAMPLER]], i32 0, i32 0
+// CHECK:  store i32 3, i32* [[Q_PTR]]
+// CHECK:  call cc75 void @foo(%opencl.sampler_t* byval [[Q_SAMPLER]])
+
+    foo(CLK_NORMALIZED_COORDS_TRUE|CLK_ADDRESS_REPEAT);
+// CHECK: [[LIT_PTR:%.*]] = getelementptr inbounds %opencl.sampler_t* [[LITERAL_ARG]], i32 0, i32 0
+// CHECK:  store i32 3, i32* [[LIT_PTR]]
+// CHECK:  call cc75 void @foo(%opencl.sampler_t* byval [[LITERAL_ARG]])
+
+    constant sampler_t dd = q;
+    foo(dd);
+// CHECK:  [[DD_PTR:%.*]] = bitcast %opencl.sampler_t* [[DD_SAMPLER]] to i8*
+// CHECK:  call void @llvm.memcpy.p0i8.p2i8.i32(i8* [[DD_PTR]], i8 addrspace(2)* bitcast (%opencl.sampler_t addrspace(2)* @bar.dd to i8 addrspace(2)*), i32 4, i32 4, i1 false)
+// CHECK:  call cc75 void @foo(%opencl.sampler_t* byval [[DD_SAMPLER]])
+
+    foo(1);
+// CHECK:  [[LIT_PTR:%.*]] = getelementptr inbounds %opencl.sampler_t* [[LITERAL_ARG2]], i32 0, i32 0
+// CHECK:  store i32 1, i32* [[LIT_PTR]]
+// CHECK:  call cc75 void @foo(%opencl.sampler_t* byval [[LITERAL_ARG2]])
+
+}


### PR DESCRIPTION
Emitting %opencl.sampler_t = type { i32 } in LLVM IR instead of i32.
Doing so, we can distinguish samplers from regular integers in IR.
