### PR TITLE
Re-implementation of sampler_t

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7238,7 +7238,7 @@ def err_expected_kernel_void_return_type : Error<
 def err_opencl20_global_invalid_addr_space : Error<
   "program scope variables must reside global or constant address space">;
 def err_sampler_initializer_not_integer : Error<
-  "sampler_t initialization requires integer, not %0">;
+  "sampler_t initialization requires 32-bit integer, not %0">;
 def err_event_initialization : Error<
   "cannot initialize event_t">;
 def err_event_argument_not_null : Error<

--- a/include/clang/Basic/LangOptions.def
+++ b/include/clang/Basic/LangOptions.def
@@ -222,6 +222,7 @@ LANGOPT(SanitizeAddressFieldPadding, 2, 0, "controls how aggressive is ASan "
                                            "aggressive, 2: more aggressive)")
 
 LANGOPT(CLEnableHalf            , 1, 0, "cl-enable-half flag used")
+LANGOPT(CLKeepSamplerType, 1, 0, "Preserve type of sampler variables in emitted SPIR")
 
 #undef LANGOPT
 #undef COMPATIBLE_LANGOPT

--- a/include/clang/Driver/CC1Options.td
+++ b/include/clang/Driver/CC1Options.td
@@ -605,7 +605,8 @@ def cl_enable_half : Flag<["-"], "cl-enable-half">,
 // SPIR generator options
 def cl_spir_compile_options : Separate<["-"], "cl-spir-compile-options">,
   HelpText<"SPIR compilation options to record in metadata">;
-
+def cl_keep_sampler_type : Flag<["-"], "cl-keep-sampler-type">,
+  HelpText<"OpenCL only. Preserve type of sampler variables in emitted IR">;
 //===----------------------------------------------------------------------===//
 // CUDA Options
 //===----------------------------------------------------------------------===//

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1672,6 +1672,8 @@ const char *CastExpr::getCastKindName() const {
     return "ZeroToOCLQueue";
   case CK_AddressSpaceConversion:
     return "AddressSpaceConversion";
+  case CK_IntToOCLSampler:
+    return "IntToOCLSampler";
   }
 
   llvm_unreachable("Unhandled cast kind!");

--- a/lib/CodeGen/CGCall.cpp
+++ b/lib/CodeGen/CGCall.cpp
@@ -1746,7 +1746,7 @@ void CodeGenFunction::EmitFunctionProlog(const CGFunctionInfo &FI,
       assert(NumIRArgs == 1);
       llvm::Value *V = FnArgs[FirstIRArg];
 
-      if (!hasScalarEvaluationKind(Ty)) {
+      if (!hasScalarEvaluationKind(Ty, getLangOpts().CLKeepSamplerType)) {
         // Aggregates and complex variables are accessed by reference.  All we
         // need to do is realign the value, if requested
         if (ArgI.getIndirectRealign()) {
@@ -2763,7 +2763,8 @@ void CodeGenFunction::EmitCallArg(CallArgList &args, const Expr *E,
     return args.add(EmitReferenceBindingToExpr(E), type);
   }
 
-  bool HasAggregateEvalKind = hasAggregateEvaluationKind(type);
+  bool HasAggregateEvalKind =
+    hasAggregateEvaluationKind(type, CGM.getLangOpts().CLKeepSamplerType);
 
   // In the Microsoft C++ ABI, aggregate arguments are destructed by the callee.
   // However, we still have to push an EH-only cleanup in case we unwind before

--- a/lib/CodeGen/CGDecl.cpp
+++ b/lib/CodeGen/CGDecl.cpp
@@ -1124,6 +1124,11 @@ void CodeGenFunction::EmitAutoVarInit(const AutoVarEmission &emission) {
     constant = CGM.EmitConstantInit(D, this);
   }
 
+  if(type->isSamplerT() && constant) {
+    Builder.CreateStore(constant, Loc);
+    return;
+  }
+
   if (!constant) {
     LValue lv = MakeAddrLValue(Loc, type, alignment);
     lv.setNonGC(true);

--- a/lib/CodeGen/CGDecl.cpp
+++ b/lib/CodeGen/CGDecl.cpp
@@ -889,7 +889,7 @@ CodeGenFunction::EmitAutoVarAlloca(const VarDecl &D) {
     // isConstantInitializer produces wrong answers for structs with
     // reference or bitfield members, and a few other cases, and checking
     // for POD-ness protects us from some of these.
-    if (D.getInit() && (Ty->isArrayType() || Ty->isRecordType()) &&
+    if (D.getInit() && (Ty->isArrayType() || Ty->isRecordType() || Ty->isSamplerT()) &&
         (D.isConstexpr() ||
          ((Ty.isPODType(getContext()) ||
            getContext().getBaseElementType(Ty)->isObjCObjectPointerType()) &&

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -118,7 +118,7 @@ void CodeGenFunction::EmitIgnoredExpr(const Expr *E) {
 RValue CodeGenFunction::EmitAnyExpr(const Expr *E,
                                     AggValueSlot aggSlot,
                                     bool ignoreResult) {
-  switch (getEvaluationKind(E->getType())) {
+  switch (getEvaluationKind(E->getType(), getLangOpts().CLKeepSamplerType)) {
   case TEK_Scalar:
     return RValue::get(EmitScalarExpr(E, ignoreResult));
   case TEK_Complex:
@@ -137,7 +137,7 @@ RValue CodeGenFunction::EmitAnyExpr(const Expr *E,
 RValue CodeGenFunction::EmitAnyExprToTemp(const Expr *E) {
   AggValueSlot AggSlot = AggValueSlot::ignored();
 
-  if (hasAggregateEvaluationKind(E->getType()))
+  if (hasAggregateEvaluationKind(E->getType(), getLangOpts().CLKeepSamplerType))
     AggSlot = CreateAggTemp(E->getType(), "agg.tmp");
   return EmitAnyExpr(E, AggSlot);
 }

--- a/lib/CodeGen/CGExprAgg.cpp
+++ b/lib/CodeGen/CGExprAgg.cpp
@@ -1384,7 +1384,8 @@ static void CheckAggExprForMemSetUse(AggValueSlot &Slot, const Expr *E,
 /// the value of the aggregate expression is not needed.  If VolatileDest is
 /// true, DestPtr cannot be 0.
 void CodeGenFunction::EmitAggExpr(const Expr *E, AggValueSlot Slot) {
-  assert(E && hasAggregateEvaluationKind(E->getType()) &&
+  assert(E && hasAggregateEvaluationKind(E->getType(),
+                                         getLangOpts().CLKeepSamplerType) &&
          "Invalid aggregate expression to emit");
   assert((Slot.getAddr() != nullptr || Slot.isIgnored()) &&
          "slot has bits but no address");
@@ -1464,7 +1465,7 @@ void CodeGenFunction::EmitAggregateCopy(llvm::Value *DestPtr,
   // we need to use a different call here.  We use isVolatile to indicate when
   // either the source or the destination is volatile.
 
-  if(Ty->isSamplerT()) {
+  if(Ty->isSamplerT() && CGM.getLangOpts().CLKeepSamplerType) {
     llvm::LoadInst *src_smp = Builder.CreateLoad(SrcPtr);
     Builder.CreateStore(src_smp, DestPtr);
     return;

--- a/lib/CodeGen/CGExprAgg.cpp
+++ b/lib/CodeGen/CGExprAgg.cpp
@@ -1464,6 +1464,12 @@ void CodeGenFunction::EmitAggregateCopy(llvm::Value *DestPtr,
   // we need to use a different call here.  We use isVolatile to indicate when
   // either the source or the destination is volatile.
 
+  if(Ty->isSamplerT()) {
+    llvm::LoadInst *src_smp = Builder.CreateLoad(SrcPtr);
+    Builder.CreateStore(src_smp, DestPtr);
+    return;
+  }
+
   llvm::PointerType *DPT = cast<llvm::PointerType>(DestPtr->getType());
   llvm::Type *DBP =
     llvm::Type::getInt8PtrTy(getLLVMContext(), DPT->getAddressSpace());

--- a/lib/CodeGen/CGExprConstant.cpp
+++ b/lib/CodeGen/CGExprConstant.cpp
@@ -657,8 +657,17 @@ public:
     case CK_NonAtomicToAtomic:
     case CK_NoOp:
     case CK_ConstructorConversion:
-    case CK_IntToOCLSampler:
       return C;
+
+    case CK_IntToOCLSampler: {
+      llvm::StructType* STy = CGM.getModule().getTypeByName("opencl.sampler_t");
+      if(STy == nullptr) {
+        STy = llvm::StructType::create(CGM.getLLVMContext(), C->getType(),
+                                       "opencl.sampler_t");
+      }
+      return llvm::ConstantStruct::get(STy, C);
+    }
+
 
     case CK_Dependent: llvm_unreachable("saw dependent cast!");
 

--- a/lib/CodeGen/CGExprConstant.cpp
+++ b/lib/CodeGen/CGExprConstant.cpp
@@ -660,6 +660,8 @@ public:
       return C;
 
     case CK_IntToOCLSampler: {
+      if (!CGM.getLangOpts().CLKeepSamplerType)
+        return C;
       llvm::StructType* STy = CGM.getModule().getTypeByName("opencl.sampler_t");
       if(STy == nullptr) {
         STy = llvm::StructType::create(CGM.getLLVMContext(), C->getType(),

--- a/lib/CodeGen/CGOpenCLRuntime.cpp
+++ b/lib/CodeGen/CGOpenCLRuntime.cpp
@@ -77,8 +77,11 @@ llvm::Type *CGOpenCLRuntime::convertOpenCLSpecificType(const Type *T) {
     return llvm::PointerType::get(llvm::StructType::create(
                            Ctx, "opencl.image3d_t"), ImgAddrSpc);
   case BuiltinType::OCLSampler:
-    return llvm::StructType::create(Ctx, llvm::IntegerType::get(Ctx, 32),
-                          "opencl.sampler_t");
+    if (CGM.getLangOpts().CLKeepSamplerType)
+      return llvm::StructType::create(Ctx, llvm::IntegerType::get(Ctx, 32),
+                                      "opencl.sampler_t");
+    else
+      return llvm::IntegerType::get(Ctx, 32);
   case BuiltinType::OCLEvent:
     return llvm::PointerType::get(llvm::StructType::create(
                            Ctx, "opencl.event_t"), 0);

--- a/lib/CodeGen/CGOpenCLRuntime.cpp
+++ b/lib/CodeGen/CGOpenCLRuntime.cpp
@@ -77,7 +77,8 @@ llvm::Type *CGOpenCLRuntime::convertOpenCLSpecificType(const Type *T) {
     return llvm::PointerType::get(llvm::StructType::create(
                            Ctx, "opencl.image3d_t"), ImgAddrSpc);
   case BuiltinType::OCLSampler:
-    return llvm::IntegerType::get(Ctx, 32);
+    return llvm::StructType::create(Ctx, llvm::IntegerType::get(Ctx, 32),
+                          "opencl.sampler_t");
   case BuiltinType::OCLEvent:
     return llvm::PointerType::get(llvm::StructType::create(
                            Ctx, "opencl.event_t"), 0);

--- a/lib/CodeGen/CodeGenFunction.cpp
+++ b/lib/CodeGen/CodeGenFunction.cpp
@@ -111,6 +111,7 @@ llvm::Type *CodeGenFunction::ConvertType(QualType T) {
 
 TypeEvaluationKind CodeGenFunction::getEvaluationKind(QualType type) {
   type = type.getCanonicalType();
+  if(type->isSamplerT()) return TEK_Aggregate;
   while (true) {
     switch (type->getTypeClass()) {
 #define TYPE(name, parent)

--- a/lib/CodeGen/CodeGenFunction.cpp
+++ b/lib/CodeGen/CodeGenFunction.cpp
@@ -109,9 +109,12 @@ llvm::Type *CodeGenFunction::ConvertType(QualType T) {
   return CGM.getTypes().ConvertType(T);
 }
 
-TypeEvaluationKind CodeGenFunction::getEvaluationKind(QualType type) {
+TypeEvaluationKind CodeGenFunction::getEvaluationKind(QualType type,
+                                                      bool keepSamplerType) {
   type = type.getCanonicalType();
-  if(type->isSamplerT()) return TEK_Aggregate;
+  if(type->isSamplerT() && keepSamplerType) {
+    return TEK_Aggregate;
+  }
   while (true) {
     switch (type->getTypeClass()) {
 #define TYPE(name, parent)

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -1379,14 +1379,17 @@ public:
 
   /// hasAggregateLLVMType - Return true if the specified AST type will map into
   /// an aggregate LLVM type or is void.
-  static TypeEvaluationKind getEvaluationKind(QualType T);
+  static TypeEvaluationKind getEvaluationKind(QualType T,
+                                              bool keepSamplerType = false);
 
-  static bool hasScalarEvaluationKind(QualType T) {
-    return getEvaluationKind(T) == TEK_Scalar;
+  static bool hasScalarEvaluationKind(QualType T,
+                                      bool keepSamplerType = false) {
+    return getEvaluationKind(T, keepSamplerType) == TEK_Scalar;
   }
 
-  static bool hasAggregateEvaluationKind(QualType T) {
-    return getEvaluationKind(T) == TEK_Aggregate;
+  static bool hasAggregateEvaluationKind(QualType T,
+                                         bool keepSamplerType = false) {
+    return getEvaluationKind(T, keepSamplerType) == TEK_Aggregate;
   }
 
   /// createBasicBlock - Create an LLVM basic block.

--- a/lib/CodeGen/TargetInfo.cpp
+++ b/lib/CodeGen/TargetInfo.cpp
@@ -42,8 +42,8 @@ static void AssignToArrayRange(CodeGen::CGBuilderTy &Builder,
   }
 }
 
-static bool isAggregateTypeForABI(QualType T) {
-  return !CodeGenFunction::hasScalarEvaluationKind(T) ||
+static bool isAggregateTypeForABI(QualType T, bool keepSamplerType = false) {
+  return !CodeGenFunction::hasScalarEvaluationKind(T, keepSamplerType) ||
          T->isMemberFunctionPointerType();
 }
 
@@ -416,7 +416,7 @@ llvm::Value *DefaultABIInfo::EmitVAArg(llvm::Value *VAListAddr, QualType Ty,
 }
 
 ABIArgInfo DefaultABIInfo::classifyArgumentType(QualType Ty) const {
-  if (isAggregateTypeForABI(Ty))
+  if (isAggregateTypeForABI(Ty, getContext().getLangOpts().CLKeepSamplerType))
     return ABIArgInfo::getIndirect(0);
 
   // Treat an enum type as its underlying type.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1680,6 +1680,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   Opts.SanitizeAddressFieldPadding =
       getLastArgIntValue(Args, OPT_fsanitize_address_field_padding, 0, Diags);
   Opts.SanitizerBlacklistFile = Args.getLastArgValue(OPT_fsanitize_blacklist);
+  Opts.CLKeepSamplerType = Args.hasArg(OPT_cl_keep_sampler_type);
 }
 
 static void ParsePreprocessorArgs(PreprocessorOptions &Opts, ArgList &Args,

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -2261,6 +2261,11 @@ void CastOperation::CheckCStyleCast() {
       return;
     }
 
+    if(SrcType->isIntegerType() && DestType->isSamplerT()) {
+      Kind = CK_IntToOCLSampler;
+      return;
+    }
+
     // Reject any other conversions to non-scalar types.
     Self.Diag(OpRange.getBegin(), diag::err_typecheck_cond_expect_scalar)
       << DestType << SrcExpr.get()->getSourceRange();

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -2261,7 +2261,8 @@ void CastOperation::CheckCStyleCast() {
       return;
     }
 
-    if(SrcType->isIntegerType() && DestType->isSamplerT()) {
+    if (SrcType->isIntegerType() && DestType->isSamplerT() &&
+        Self.getLangOpts().CLKeepSamplerType) {
       Kind = CK_IntToOCLSampler;
       return;
     }

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -7046,6 +7046,11 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
     }
   }
 
+  if (LHSType->isSamplerT() && RHSType->isIntegerType()) {
+    Kind = CK_IntToOCLSampler;
+    return Compatible;
+  }
+
   return Incompatible;
 }
 

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -4485,8 +4485,7 @@ static bool TryOCLSamplerInitialization(Sema &S,
                                         InitializationSequence &Sequence,
                                         QualType DestType,
                                         Expr *Initializer) {
-  if (!S.getLangOpts().OpenCL || !DestType->isSamplerT() ||
-    !Initializer->isIntegerConstantExpr(S.getASTContext()))
+  if (!S.getLangOpts().OpenCL || !DestType->isSamplerT())
     return false;
 
   Sequence.AddOCLSamplerInitStep(DestType);
@@ -6373,19 +6372,27 @@ InitializationSequence::Perform(Sema &S,
       bool isConst = CurInit.get()->isConstantInitializer(S.Context, false);
       InitializedEntity::EntityKind EntityKind = Entity.getKind();
 
-      if (EntityKind == InitializedEntity::EK_Variable ||
-          EntityKind == InitializedEntity::EK_Parameter) {
+      if (SourceType->isSamplerT() && DestType->isSamplerT()) {
+        // copy-assignment or copy-initialization
+      }
+      else if (EntityKind == InitializedEntity::EK_Variable ||
+               EntityKind == InitializedEntity::EK_Parameter) {
         if (!isConst)
           S.Diag(Kind.getLocation(), diag::err_sampler_initializer_not_constant);
-        else if (!SourceType->isIntegerType())
+        if (!SourceType->isIntegerType() ||
+            32 != S.Context.getIntWidth(SourceType))
           S.Diag(Kind.getLocation(), diag::err_sampler_initializer_not_integer)
             << SourceType;
       } else
         llvm_unreachable("Invalid EntityKind!");
 
-      CurInit = S.ImpCastExprToType(CurInit.get(), Step->Type,
-                                    CK_IntToOCLSampler,
-                                    CurInit.get()->getValueKind());
+      ExprResult Result = CurInit;
+      Sema::AssignConvertType ConvTy =
+        S.CheckSingleAssignmentConstraints(Step->Type, Result, true,
+            Entity.getKind() == InitializedEntity::EK_Parameter_CF_Audited);
+      if (Result.isInvalid())
+        return ExprError();
+      CurInit = Result;
       break;
     }
     case SK_OCLZeroEvent: {

--- a/test/CodeGenOpenCL/address-spaces-ocl20.cl
+++ b/test/CodeGenOpenCL/address-spaces-ocl20.cl
@@ -13,7 +13,7 @@ global int *global baz_ptr = &baz;
 // CHECK: @baz_ptr = addrspace(1) global i32 addrspace(1)* @baz, align 4
 
 const sampler_t sampler = 10;
-// CHECK: @sampler = constant i32 10, align 4
+// CHECK: @sampler = constant %opencl.sampler_t { i32 10 }, align 4
 
 static global int bat; // OK. Internal linkage
 // CHECK: @bat = internal addrspace(1) global i32 0, align 4

--- a/test/CodeGenOpenCL/address-spaces-ocl20.cl
+++ b/test/CodeGenOpenCL/address-spaces-ocl20.cl
@@ -13,7 +13,7 @@ global int *global baz_ptr = &baz;
 // CHECK: @baz_ptr = addrspace(1) global i32 addrspace(1)* @baz, align 4
 
 const sampler_t sampler = 10;
-// CHECK: @sampler = constant %opencl.sampler_t { i32 10 }, align 4
+// CHECK: @sampler = constant i32 10, align 4
 
 static global int bat; // OK. Internal linkage
 // CHECK: @bat = internal addrspace(1) global i32 0, align 4

--- a/test/CodeGenOpenCL/opencl_types.cl
+++ b/test/CodeGenOpenCL/opencl_types.cl
@@ -1,47 +1,46 @@
-// RUN: %clang_cc1 %s -emit-llvm -o - -O0 | FileCheck %s
+// RUN: %clang_cc1 %s -emit-llvm -triple spir-unknown-unknown -o - -O0 | FileCheck %s
 
 constant sampler_t glb_smp = 7;
 // CHECK: constant %opencl.sampler_t { i32 7 }
 
 void fnc1(image1d_t img) {}
-// CHECK: @fnc1(%opencl.image1d_t*
+// CHECK: @fnc1(%opencl.image1d_t {{.*}}*
 
 void fnc1arr(image1d_array_t img) {}
-// CHECK: @fnc1arr(%opencl.image1d_array_t*
+// CHECK: @fnc1arr(%opencl.image1d_array_t {{.*}}*
 
 void fnc1buff(image1d_buffer_t img) {}
-// CHECK: @fnc1buff(%opencl.image1d_buffer_t*
+// CHECK: @fnc1buff(%opencl.image1d_buffer_t {{.*}}*
 
 void fnc2(image2d_t img) {}
-// CHECK: @fnc2(%opencl.image2d_t*
+// CHECK: @fnc2(%opencl.image2d_t {{.*}}*
 
 void fnc2arr(image2d_array_t img) {}
-// CHECK: @fnc2arr(%opencl.image2d_array_t*
+// CHECK: @fnc2arr(%opencl.image2d_array_t {{.*}}*
 
 void fnc3(image3d_t img) {}
-// CHECK: @fnc3(%opencl.image3d_t*
+// CHECK: @fnc3(%opencl.image3d_t {{.*}}*
 
 void fnc4smp(sampler_t s) {}
-// CHECK: define void @fnc4smp(i32
+// CHECK: @fnc4smp(%opencl.sampler_t* byval
 
 kernel void foo(image1d_t img) {
-// CHECK: define void @foo(%opencl.image1d_t*
+  // CHECK: define spir_kernel void @foo(%opencl.image1d_t {{.*}}*
 
   sampler_t smp = 5;
-// CHECK: alloca %opencl.sampler_t
+  // CHECK: [[SMP_PTR:%[A-Za-z0-9_\.]+]] = alloca %opencl.sampler_t
 
 	event_t evt;
-// CHECK: alloca %opencl.event_t*
+  // CHECK: alloca %opencl.event_t*
 
-fnc4smp(smp);
-// CHECK: [[SMP_ELEM_PTR:%[A-Za-z0-9_\.]+]] = getelementptr %opencl.sampler_t* {{.*}}, i32 0, i32 0
-// CHECK: [[SMP_VAL:%[A-Za-z0-9_\.]+]] = load i32* [[SMP_ELEM_PTR]]
-// CHECK: call void @fnc4smp(i32 [[SMP_VAL]]
+  fnc4smp(smp);
+  // CHECK: store %opencl.sampler_t { i32 5 }, %opencl.sampler_t* [[SMP_PTR]]
+  // CHECK: call spir_func void @fnc4smp(%opencl.sampler_t* byval [[SMP_PTR]])
 
   fnc4smp(glb_smp);
-// CHECK-DAG: getelementptr {{[a-z]* ?\(?}}%opencl.sampler_t* {{.*}}, i32 0, i32 0
-// CHECK-DAG: [[SMP_VAL:%[A-Za-z0-9_\.]+]] = load i32*
-// CHECK: call void @fnc4smp(i32 [[SMP_VAL]]
+  // CHECK: [[SMP:%[A-Za-z0-9_\.]+]] = load %opencl.sampler_t addrspace(2)* @glb_smp
+  // CHECK: store %opencl.sampler_t [[SMP]], %opencl.sampler_t* [[TMP:%[A-Za-z0-9_\.]+]]
+  // CHECK: call spir_func void @fnc4smp(%opencl.sampler_t* byval [[TMP]])
 }
 
 void __attribute__((overloadable)) bad1(image1d_t b, image2d_t c, image2d_t d) {}

--- a/test/CodeGenOpenCL/sampler_t.cl
+++ b/test/CodeGenOpenCL/sampler_t.cl
@@ -1,0 +1,68 @@
+// RUN: %clang_cc1 %s -triple spir-unknown-unknown -emit-llvm -o - -O0 | FileCheck %s
+
+// CHECK: %opencl.sampler_t = type { i32 }
+
+#define CLK_NORMALIZED_COORDS_TRUE 0x01
+#define CLK_ADDRESS_REPEAT 0x02
+#define CLK_FILTER_NEAREST 0x04
+
+const sampler_t gs = 2;
+// CHECK: @gs = constant %opencl.sampler_t { i32 2 }, align 4
+
+constant sampler_t cgs = 3;
+// CHECK: @cgs = addrspace(2) constant %opencl.sampler_t { i32 3 }, align 4
+
+// CHECK: @bar.kst = internal constant %opencl.sampler_t { i32 5 }, align 4
+// CHECK: @bar.cst = internal addrspace(2) constant %opencl.sampler_t { i32 6 }, align 4
+// CHECK: @bar.lst = internal constant %opencl.sampler_t { i32 7 }, align 4
+// CHECK: @bar.dd = internal addrspace(2) constant %opencl.sampler_t { i32 3 }, align 4
+
+
+void foo(const sampler_t st){}
+// CHECK: define spir_func void @foo(%opencl.sampler_t* byval %st)
+
+kernel void bar(const sampler_t ast) {
+// CHECK: define spir_kernel void @bar(%opencl.sampler_t* byval %ast)
+
+// CHECK: {{.*}} = alloca %opencl.sampler_t, align 4
+// CHECK: [[Q_SAMPLER:%[A-Za-z0-9_\.]+]] = alloca %opencl.sampler_t, align 4
+// CHECK: [[LITERAL_ARG:%[A-Za-z0-9_\.]+]] = alloca %opencl.sampler_t, align 4
+// CHECK: [[DD_SAMPLER:%[A-Za-z0-9_\.]+]] = alloca %opencl.sampler_t, align 4
+// CHECK: [[LITERAL_ARG2:%[A-Za-z0-9_\.]+]] = alloca %opencl.sampler_t, align 4
+
+    const sampler_t kst = 5;
+    foo(kst);
+// CHECK: call spir_func void @foo(%opencl.sampler_t* byval @bar.kst)
+
+    constant sampler_t cst = 6;
+    const sampler_t ost = cst;
+// CHECK: [[OST:%[A-Za-z0-9_\.]+]] = bitcast %opencl.sampler_t* %ost to i8*
+// CHECK: call void @llvm.memcpy.p0i8.p2i8.i32(i8* [[OST]], i8 addrspace(2)* bitcast (%opencl.sampler_t addrspace(2)* @bar.cst to i8 addrspace(2)*), i32 4, i32 4, i1 false)
+
+    const sampler_t lst = CLK_NORMALIZED_COORDS_TRUE|CLK_ADDRESS_REPEAT|CLK_FILTER_NEAREST;
+    foo(lst);
+// CHECK: call spir_func void @foo(%opencl.sampler_t* byval @bar.lst)
+
+    const int q = CLK_NORMALIZED_COORDS_TRUE|CLK_ADDRESS_REPEAT;
+    foo(q);
+// CHECK: [[Q_PTR:%[A-Za-z0-9_\.]+]] = getelementptr inbounds %opencl.sampler_t* [[Q_SAMPLER]], i32 0, i32 0
+// CHECK:  store i32 3, i32* [[Q_PTR]]
+// CHECK:  call spir_func void @foo(%opencl.sampler_t* byval [[Q_SAMPLER]])
+
+    foo(CLK_NORMALIZED_COORDS_TRUE|CLK_ADDRESS_REPEAT);
+// CHECK: [[LIT_PTR:%[A-Za-z0-9_\.]+]] = getelementptr inbounds %opencl.sampler_t* [[LITERAL_ARG]], i32 0, i32 0
+// CHECK:  store i32 3, i32* [[LIT_PTR]]
+// CHECK:  call spir_func void @foo(%opencl.sampler_t* byval [[LITERAL_ARG]])
+
+    constant sampler_t dd = q;
+    foo(dd);
+// CHECK:  [[DD_PTR:%[A-Za-z0-9_\.]+]] = bitcast %opencl.sampler_t* [[DD_SAMPLER]] to i8*
+// CHECK:  call void @llvm.memcpy.p0i8.p2i8.i32(i8* [[DD_PTR]], i8 addrspace(2)* bitcast (%opencl.sampler_t addrspace(2)* @bar.dd to i8 addrspace(2)*), i32 4, i32 4, i1 false)
+// CHECK:  call spir_func void @foo(%opencl.sampler_t* byval [[DD_SAMPLER]])
+
+    foo(1);
+// CHECK:  [[LIT_PTR:%[A-Za-z0-9_\.]+]] = getelementptr inbounds %opencl.sampler_t* [[LITERAL_ARG2]], i32 0, i32 0
+// CHECK:  store i32 1, i32* [[LIT_PTR]]
+// CHECK:  call spir_func void @foo(%opencl.sampler_t* byval [[LITERAL_ARG2]])
+
+}

--- a/test/CodeGenOpenCL/sampler_t.cl
+++ b/test/CodeGenOpenCL/sampler_t.cl
@@ -36,8 +36,8 @@ kernel void bar(const sampler_t ast) {
 
     constant sampler_t cst = 6;
     const sampler_t ost = cst;
-// CHECK: [[OST:%[A-Za-z0-9_\.]+]] = bitcast %opencl.sampler_t* %ost to i8*
-// CHECK: call void @llvm.memcpy.p0i8.p2i8.i32(i8* [[OST]], i8 addrspace(2)* bitcast (%opencl.sampler_t addrspace(2)* @bar.cst to i8 addrspace(2)*), i32 4, i32 4, i1 false)
+// CHECK: [[SMP:%[0-9]+]] = load %opencl.sampler_t addrspace(2)* @bar.cst
+// CHECK: store %opencl.sampler_t [[SMP]], %opencl.sampler_t* %ost
 
     const sampler_t lst = CLK_NORMALIZED_COORDS_TRUE|CLK_ADDRESS_REPEAT|CLK_FILTER_NEAREST;
     foo(lst);
@@ -46,23 +46,23 @@ kernel void bar(const sampler_t ast) {
     const int q = CLK_NORMALIZED_COORDS_TRUE|CLK_ADDRESS_REPEAT;
     foo(q);
 // CHECK: [[Q_PTR:%[A-Za-z0-9_\.]+]] = getelementptr inbounds %opencl.sampler_t* [[Q_SAMPLER]], i32 0, i32 0
-// CHECK:  store i32 3, i32* [[Q_PTR]]
-// CHECK:  call spir_func void @foo(%opencl.sampler_t* byval [[Q_SAMPLER]])
+// CHECK: store i32 3, i32* [[Q_PTR]]
+// CHECK: call spir_func void @foo(%opencl.sampler_t* byval [[Q_SAMPLER]])
 
     foo(CLK_NORMALIZED_COORDS_TRUE|CLK_ADDRESS_REPEAT);
 // CHECK: [[LIT_PTR:%[A-Za-z0-9_\.]+]] = getelementptr inbounds %opencl.sampler_t* [[LITERAL_ARG]], i32 0, i32 0
-// CHECK:  store i32 3, i32* [[LIT_PTR]]
-// CHECK:  call spir_func void @foo(%opencl.sampler_t* byval [[LITERAL_ARG]])
+// CHECK: store i32 3, i32* [[LIT_PTR]]
+// CHECK: call spir_func void @foo(%opencl.sampler_t* byval [[LITERAL_ARG]])
 
     constant sampler_t dd = q;
     foo(dd);
-// CHECK:  [[DD_PTR:%[A-Za-z0-9_\.]+]] = bitcast %opencl.sampler_t* [[DD_SAMPLER]] to i8*
-// CHECK:  call void @llvm.memcpy.p0i8.p2i8.i32(i8* [[DD_PTR]], i8 addrspace(2)* bitcast (%opencl.sampler_t addrspace(2)* @bar.dd to i8 addrspace(2)*), i32 4, i32 4, i1 false)
-// CHECK:  call spir_func void @foo(%opencl.sampler_t* byval [[DD_SAMPLER]])
+// CHECK: [[SMP:%[0-9]+]] = load %opencl.sampler_t addrspace(2)* @bar.dd
+// CHECK: store %opencl.sampler_t [[SMP]], %opencl.sampler_t* [[TMP:%[A-Za-z0-9_\.]+]]
+// CHECK: call spir_func void @foo(%opencl.sampler_t* byval [[TMP]])
 
     foo(1);
-// CHECK:  [[LIT_PTR:%[A-Za-z0-9_\.]+]] = getelementptr inbounds %opencl.sampler_t* [[LITERAL_ARG2]], i32 0, i32 0
-// CHECK:  store i32 1, i32* [[LIT_PTR]]
-// CHECK:  call spir_func void @foo(%opencl.sampler_t* byval [[LITERAL_ARG2]])
+// CHECK: [[LIT_PTR:%[A-Za-z0-9_\.]+]] = getelementptr inbounds %opencl.sampler_t* [[LITERAL_ARG2]], i32 0, i32 0
+// CHECK: store i32 1, i32* [[LIT_PTR]]
+// CHECK: call spir_func void @foo(%opencl.sampler_t* byval [[LITERAL_ARG2]])
 
 }

--- a/test/CodeGenOpenCL/sampler_t.cl
+++ b/test/CodeGenOpenCL/sampler_t.cl
@@ -1,68 +1,89 @@
-// RUN: %clang_cc1 %s -triple spir-unknown-unknown -emit-llvm -o - -O0 | FileCheck %s
+// RUN: %clang_cc1 %s -emit-llvm -triple spir-unknown-unknown -o - -O0 | FileCheck %s
+// RUN: %clang_cc1 %s -emit-llvm -triple spir-unknown-unknown -o - -O0 -cl-keep-sampler-type | FileCheck -check-prefix CHECK-SAMPLER-TYPE %s
 
-// CHECK: %opencl.sampler_t = type { i32 }
+// CHECK-SAMPLER-TYPE: %opencl.sampler_t = type { i32 }
 
 #define CLK_NORMALIZED_COORDS_TRUE 0x01
 #define CLK_ADDRESS_REPEAT 0x02
 #define CLK_FILTER_NEAREST 0x04
 
 const sampler_t gs = 2;
-// CHECK: @gs = constant %opencl.sampler_t { i32 2 }, align 4
+// CHECK: @gs = constant i32 2
+// CHECK-SAMPLER-TYPE: @gs = constant %opencl.sampler_t { i32 2 }, align 4
 
 constant sampler_t cgs = 3;
-// CHECK: @cgs = addrspace(2) constant %opencl.sampler_t { i32 3 }, align 4
+// CHECK: @cgs = addrspace(2) constant i32 3
+// CHECK-SAMPLER-TYPE: @cgs = addrspace(2) constant %opencl.sampler_t { i32 3 }, align 4
 
-// CHECK: @bar.kst = internal constant %opencl.sampler_t { i32 5 }, align 4
-// CHECK: @bar.cst = internal addrspace(2) constant %opencl.sampler_t { i32 6 }, align 4
-// CHECK: @bar.lst = internal constant %opencl.sampler_t { i32 7 }, align 4
-// CHECK: @bar.dd = internal addrspace(2) constant %opencl.sampler_t { i32 3 }, align 4
-
+// CHECK: @bar.cst = internal addrspace(2) constant i32 6
+// CHECK: @bar.dd = internal addrspace(2) constant i32 3
+// CHECK-SAMPLER-TYPE: @bar.kst = internal constant %opencl.sampler_t { i32 5 }, align 4
+// CHECK-SAMPLER-TYPE: @bar.cst = internal addrspace(2) constant %opencl.sampler_t { i32 6 }, align 4
+// CHECK-SAMPLER-TYPE: @bar.lst = internal constant %opencl.sampler_t { i32 7 }, align 4
+// CHECK-SAMPLER-TYPE: @bar.dd = internal addrspace(2) constant %opencl.sampler_t { i32 3 }, align 4
 
 void foo(const sampler_t st){}
-// CHECK: define spir_func void @foo(%opencl.sampler_t* byval %st)
+// CHECK: define spir_func void @foo(i32
+// CHECK-SAMPLER-TYPE: define spir_func void @foo(%opencl.sampler_t* byval %st)
 
 kernel void bar(const sampler_t ast) {
-// CHECK: define spir_kernel void @bar(%opencl.sampler_t* byval %ast)
+// CHECK: define spir_kernel void @bar(i32
+// CHECK-SAMPLER-TYPE: define spir_kernel void @bar(%opencl.sampler_t* byval %ast)
 
-// CHECK: {{.*}} = alloca %opencl.sampler_t, align 4
-// CHECK: [[Q_SAMPLER:%[A-Za-z0-9_\.]+]] = alloca %opencl.sampler_t, align 4
-// CHECK: [[LITERAL_ARG:%[A-Za-z0-9_\.]+]] = alloca %opencl.sampler_t, align 4
-// CHECK: [[DD_SAMPLER:%[A-Za-z0-9_\.]+]] = alloca %opencl.sampler_t, align 4
-// CHECK: [[LITERAL_ARG2:%[A-Za-z0-9_\.]+]] = alloca %opencl.sampler_t, align 4
+// CHECK: {{.*}} = alloca i32
+// CHECK: %kst = alloca i32
+// CHECK: %ost = alloca i32
+// CHECK: %lst = alloca i32
+// CHECK: %q = alloca i32
+
+// CHECK-SAMPLER-TYPE: {{.*}} = alloca %opencl.sampler_t, align 4
+// CHECK-SAMPLER-TYPE: [[Q_SAMPLER:%[A-Za-z0-9_\.]+]] = alloca %opencl.sampler_t, align 4
+// CHECK-SAMPLER-TYPE: [[LITERAL_ARG:%[A-Za-z0-9_\.]+]] = alloca %opencl.sampler_t, align 4
+// CHECK-SAMPLER-TYPE: [[DD_SAMPLER:%[A-Za-z0-9_\.]+]] = alloca %opencl.sampler_t, align 4
+// CHECK-SAMPLER-TYPE: [[LITERAL_ARG2:%[A-Za-z0-9_\.]+]] = alloca %opencl.sampler_t, align 4
 
     const sampler_t kst = 5;
     foo(kst);
-// CHECK: call spir_func void @foo(%opencl.sampler_t* byval @bar.kst)
+// CHECK: call spir_func void @foo(i32
+// CHECK-SAMPLER-TYPE: call spir_func void @foo(%opencl.sampler_t* byval @bar.kst)
 
     constant sampler_t cst = 6;
     const sampler_t ost = cst;
-// CHECK: [[SMP:%[0-9]+]] = load %opencl.sampler_t addrspace(2)* @bar.cst
-// CHECK: store %opencl.sampler_t [[SMP]], %opencl.sampler_t* %ost
+// CHECK: [[CST:%[0-9]+]] = load i32 addrspace(2)* @bar.cst
+// CHECK: store i32 [[CST]], i32* %ost
+// CHECK-SAMPLER-TYPE: [[SMP:%[0-9]+]] = load %opencl.sampler_t addrspace(2)* @bar.cst
+// CHECK-SAMPLER-TYPE: store %opencl.sampler_t [[SMP]], %opencl.sampler_t* %ost
 
     const sampler_t lst = CLK_NORMALIZED_COORDS_TRUE|CLK_ADDRESS_REPEAT|CLK_FILTER_NEAREST;
     foo(lst);
-// CHECK: call spir_func void @foo(%opencl.sampler_t* byval @bar.lst)
+// CHECK: call spir_func void @foo(i32
+// CHECK-SAMPLER-TYPE: call spir_func void @foo(%opencl.sampler_t* byval @bar.lst)
 
     const int q = CLK_NORMALIZED_COORDS_TRUE|CLK_ADDRESS_REPEAT;
     foo(q);
-// CHECK: [[Q_PTR:%[A-Za-z0-9_\.]+]] = getelementptr inbounds %opencl.sampler_t* [[Q_SAMPLER]], i32 0, i32 0
-// CHECK: store i32 3, i32* [[Q_PTR]]
-// CHECK: call spir_func void @foo(%opencl.sampler_t* byval [[Q_SAMPLER]])
+// CHECK: call spir_func void @foo(i32 3)
+// CHECK-SAMPLER-TYPE: [[Q_PTR:%[A-Za-z0-9_\.]+]] = getelementptr inbounds %opencl.sampler_t* [[Q_SAMPLER]], i32 0, i32 0
+// CHECK-SAMPLER-TYPE: store i32 3, i32* [[Q_PTR]]
+// CHECK-SAMPLER-TYPE: call spir_func void @foo(%opencl.sampler_t* byval [[Q_SAMPLER]])
 
     foo(CLK_NORMALIZED_COORDS_TRUE|CLK_ADDRESS_REPEAT);
-// CHECK: [[LIT_PTR:%[A-Za-z0-9_\.]+]] = getelementptr inbounds %opencl.sampler_t* [[LITERAL_ARG]], i32 0, i32 0
-// CHECK: store i32 3, i32* [[LIT_PTR]]
-// CHECK: call spir_func void @foo(%opencl.sampler_t* byval [[LITERAL_ARG]])
+// CHECK: call spir_func void @foo(i32 3)
+// CHECK-SAMPLER-TYPE: [[LIT_PTR:%[A-Za-z0-9_\.]+]] = getelementptr inbounds %opencl.sampler_t* [[LITERAL_ARG]], i32 0, i32 0
+// CHECK-SAMPLER-TYPE: store i32 3, i32* [[LIT_PTR]]
+// CHECK-SAMPLER-TYPE: call spir_func void @foo(%opencl.sampler_t* byval [[LITERAL_ARG]])
 
     constant sampler_t dd = q;
     foo(dd);
-// CHECK: [[SMP:%[0-9]+]] = load %opencl.sampler_t addrspace(2)* @bar.dd
-// CHECK: store %opencl.sampler_t [[SMP]], %opencl.sampler_t* [[TMP:%[A-Za-z0-9_\.]+]]
-// CHECK: call spir_func void @foo(%opencl.sampler_t* byval [[TMP]])
+// CHECK: [[DD:%[A-Za-z0-9_\.]+]] = load i32 addrspace(2)* @bar.dd
+// CHECK: call spir_func void @foo(i32 [[DD]])
+// CHECK-SAMPLER-TYPE: [[SMP:%[0-9]+]] = load %opencl.sampler_t addrspace(2)* @bar.dd
+// CHECK-SAMPLER-TYPE: store %opencl.sampler_t [[SMP]], %opencl.sampler_t* [[TMP:%[A-Za-z0-9_\.]+]]
+// CHECK-SAMPLER-TYPE: call spir_func void @foo(%opencl.sampler_t* byval [[TMP]])
 
     foo(1);
-// CHECK: [[LIT_PTR:%[A-Za-z0-9_\.]+]] = getelementptr inbounds %opencl.sampler_t* [[LITERAL_ARG2]], i32 0, i32 0
-// CHECK: store i32 1, i32* [[LIT_PTR]]
-// CHECK: call spir_func void @foo(%opencl.sampler_t* byval [[LITERAL_ARG2]])
+// CHECK: call spir_func void @foo(i32 1)
+// CHECK-SAMPLER-TYPE: [[LIT_PTR:%[A-Za-z0-9_\.]+]] = getelementptr inbounds %opencl.sampler_t* [[LITERAL_ARG2]], i32 0, i32 0
+// CHECK-SAMPLER-TYPE: store i32 1, i32* [[LIT_PTR]]
+// CHECK-SAMPLER-TYPE: call spir_func void @foo(%opencl.sampler_t* byval [[LITERAL_ARG2]])
 
 }


### PR DESCRIPTION
Emitting %opencl.sampler_t = type { i32 } in LLVM IR instead of i32.
Doing so, we can distinguish samplers from regular integers in IR.
