### PR TITLE
[OpenCL][Pipes] Fixes to pipes implementation according to

### DIFF
--- a/lib/CodeGen/CGOpenCLRuntime.cpp
+++ b/lib/CodeGen/CGOpenCLRuntime.cpp
@@ -141,12 +141,12 @@ llvm::Value *CGOpenCLRuntime::getPipeElemAlign(const Expr *PipeArg) {
 Ocl20Mangler::Ocl20Mangler(llvm::SmallVectorImpl<char>& SS): MangledString(&SS) {}
 
 Ocl20Mangler& Ocl20Mangler::appendReservedId() {
-  this->appendString("16ocl_reserve_id_t");
+  this->appendString("13ocl_reserveid");
   return *this;
 }
 
 Ocl20Mangler& Ocl20Mangler::appendPipe() {
-  this->appendString("10ocl_pipe_t");
+  this->appendString("8ocl_pipe");
   return *this;
 }
 

--- a/test/OpenCL/OpenCL20/Pipes/call_commit_read_pipe.cl
+++ b/test/OpenCL/OpenCL20/Pipes/call_commit_read_pipe.cl
@@ -4,6 +4,6 @@ reserve_id_t my_mystery_function();
 
 kernel void test_reserved_commit_read_pipe(read_only pipe int Pipe) {
   reserve_id_t ID = my_mystery_function();
-// CHECK: call void @_Z16commit_read_pipePU3AS110ocl_pipe_t16ocl_reserve_id_ti(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 4)
+// CHECK: call void @_Z16commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 4, i32 4)
   commit_read_pipe (Pipe, ID);
 }

--- a/test/OpenCL/OpenCL20/Pipes/call_commit_write_pipe.cl
+++ b/test/OpenCL/OpenCL20/Pipes/call_commit_write_pipe.cl
@@ -4,6 +4,6 @@ reserve_id_t my_mystery_function();
 
 kernel void test_reserved_commit_read_pipe(read_only pipe int Pipe) {
   reserve_id_t ID = my_mystery_function();
-// CHECK: call void @_Z17commit_write_pipePU3AS110ocl_pipe_t16ocl_reserve_id_ti(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 4)
+// CHECK: call void @_Z17commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 4, i32 4)
   commit_write_pipe (Pipe, ID);
 }

--- a/test/OpenCL/OpenCL20/Pipes/call_pipe_num_packets.cl
+++ b/test/OpenCL/OpenCL20/Pipes/call_pipe_num_packets.cl
@@ -2,10 +2,10 @@
 
 void test_call_get_num_packets(pipe int Pipe, global unsigned int *N) {
   *N = get_pipe_num_packets(Pipe);
-// CHECK: call i32 @_Z20get_pipe_num_packetsPU3AS110ocl_pipe_ti(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 4)
+// CHECK: call i32 @_Z20get_pipe_num_packetsPU3AS18ocl_pipejj(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 4, i32 4)
 }
 
 void test_call_get_max_packets(pipe int Pipe, global unsigned *N) {
   *N = get_pipe_max_packets(Pipe);
-// CHECK: call i32 @_Z20get_pipe_max_packetsPU3AS110ocl_pipe_ti(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 4)
+// CHECK: call i32 @_Z20get_pipe_max_packetsPU3AS18ocl_pipejj(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 4, i32 4)
 }

--- a/test/OpenCL/OpenCL20/Pipes/call_read_pipe2.cl
+++ b/test/OpenCL/OpenCL20/Pipes/call_read_pipe2.cl
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -O0 -cl-std=CL2.0 -emit-llvm %s -o -| FileCheck %s
 
 kernel void test_reserved_read_pipe(global int *Dst, read_only pipe int OutPipe) {
-  // CHECK: call i32 @_Z9read_pipePU3AS110ocl_pipe_tPU3AS4vi(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4)
+  // CHECK: call i32 @_Z9read_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4, i32 4)
   read_pipe (OutPipe, Dst);
 }

--- a/test/OpenCL/OpenCL20/Pipes/call_read_pipe4.cl
+++ b/test/OpenCL/OpenCL20/Pipes/call_read_pipe4.cl
@@ -14,14 +14,14 @@ kernel void test_read_pipe(global int *Dst, read_only pipe int Pipe) {
   IntegerWidth iw;
   iw.Long = 0;
 // CHECK:  zext i8 %{{.*}} to i32
-// CHECK:  call i32 @_Z9read_pipePU3AS110ocl_pipe_t16ocl_reserve_id_tjPU3AS4vi(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4)
+// CHECK:  call i32 @_Z9read_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4, i32 4)
   read_pipe (Pipe, ID, iw.Char, Dst);
 // CHECK:  zext i16 %{{.*}} to i32
-// CHECK:  call i32 @_Z9read_pipePU3AS110ocl_pipe_t16ocl_reserve_id_tjPU3AS4vi(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4)
+// CHECK:  call i32 @_Z9read_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4, i32 4)
   read_pipe (Pipe, ID, iw.Short, Dst);
-// CHECK:  call i32 @_Z9read_pipePU3AS110ocl_pipe_t16ocl_reserve_id_tjPU3AS4vi(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4)
+// CHECK:  call i32 @_Z9read_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4, i32 4)
   read_pipe (Pipe, ID, iw.Int, Dst);
 // CHECK:  trunc i64 %{{.*}} to i32
-// CHECK:  call i32 @_Z9read_pipePU3AS110ocl_pipe_t16ocl_reserve_id_tjPU3AS4vi(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4)
+// CHECK:  call i32 @_Z9read_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4, i32 4)
   read_pipe (Pipe, ID, iw.Long, Dst);
 }

--- a/test/OpenCL/OpenCL20/Pipes/call_reserve_read_pipe.cl
+++ b/test/OpenCL/OpenCL20/Pipes/call_reserve_read_pipe.cl
@@ -11,14 +11,14 @@ kernel void test_reserved_read_pipe(global int *Dst, read_only pipe int OutPipe)
   IntegerWidth wi;
   wi.Long = 0;
 // CHECK:  zext i8 %{{.*}} to i32
-// CHECK: call %opencl.reserve_id_t* @_Z17reserve_read_pipePU3AS110ocl_pipe_tji(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4)
+// CHECK: call %opencl.reserve_id_t* @_Z17reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4, i32 4)
   reserve_id_t id = reserve_read_pipe (OutPipe, wi.Char);
 // CHECK:  zext i16 %{{.*}} to i32
-// CHECK: call %opencl.reserve_id_t* @_Z17reserve_read_pipePU3AS110ocl_pipe_tji(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4)
+// CHECK: call %opencl.reserve_id_t* @_Z17reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4, i32 4)
   id = reserve_read_pipe (OutPipe, wi.Short);
-// CHECK: call %opencl.reserve_id_t* @_Z17reserve_read_pipePU3AS110ocl_pipe_tji(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4)
+// CHECK: call %opencl.reserve_id_t* @_Z17reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4, i32 4)
   id = reserve_read_pipe (OutPipe, wi.Int);
 // CHECK:  trunc i64 %{{.*}} to i32
-// CHECK: call %opencl.reserve_id_t* @_Z17reserve_read_pipePU3AS110ocl_pipe_tji(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4)
+// CHECK: call %opencl.reserve_id_t* @_Z17reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4, i32 4)
   id = reserve_read_pipe (OutPipe, wi.Long);
 }

--- a/test/OpenCL/OpenCL20/Pipes/call_reserve_write_pipe.cl
+++ b/test/OpenCL/OpenCL20/Pipes/call_reserve_write_pipe.cl
@@ -11,14 +11,14 @@ kernel void test_reserved_write_pipe(global int *Dst, read_only pipe int OutPipe
   IntegerWidth iw;
   iw.Long = 0;
   // CHECK:  zext i8 %{{.*}} to i32
-  // CHECK: call %opencl.reserve_id_t* @_Z18reserve_write_pipePU3AS110ocl_pipe_tji(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4)
+  // CHECK: call %opencl.reserve_id_t* @_Z18reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4, i32 4)
   reserve_id_t id = reserve_write_pipe (OutPipe, iw.Char);
   // CHECK:  zext i16 %{{.*}} to i32
-  // CHECK: call %opencl.reserve_id_t* @_Z18reserve_write_pipePU3AS110ocl_pipe_tji(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4)
+  // CHECK: call %opencl.reserve_id_t* @_Z18reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4, i32 4)
   id = reserve_write_pipe (OutPipe, iw.Short);
-  // CHECK: call %opencl.reserve_id_t* @_Z18reserve_write_pipePU3AS110ocl_pipe_tji(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4)
+  // CHECK: call %opencl.reserve_id_t* @_Z18reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4, i32 4)
   id = reserve_write_pipe (OutPipe, iw.Int);
   // CHECK:  trunc i64 %{{.*}} to i32
-  // CHECK: call %opencl.reserve_id_t* @_Z18reserve_write_pipePU3AS110ocl_pipe_tji(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4)
+  // CHECK: call %opencl.reserve_id_t* @_Z18reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 %{{.*}}, i32 4, i32 4)
   id = reserve_write_pipe (OutPipe, iw.Long);
 }

--- a/test/OpenCL/OpenCL20/Pipes/call_sg_pipes.cl
+++ b/test/OpenCL/OpenCL20/Pipes/call_sg_pipes.cl
@@ -3,23 +3,23 @@
 extern reserve_id_t my_mystery_function();
 
 reserve_id_t test_call_read_pipe(pipe int Pipe) {
-// CHECK: call %opencl.reserve_id_t* @_Z27sub_group_reserve_read_pipePU3AS110ocl_pipe_tji(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 4, i32 4)
+// CHECK: call %opencl.reserve_id_t* @_Z27sub_group_reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 4, i32 4, i32 4)
   return sub_group_reserve_read_pipe(Pipe, 4U);
 }
 
 reserve_id_t test_call_write_pipe(pipe int Pipe) {
-// CHECK: call %opencl.reserve_id_t* @_Z28sub_group_reserve_write_pipePU3AS110ocl_pipe_tji(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 4, i32 4)
+// CHECK: call %opencl.reserve_id_t* @_Z28sub_group_reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 4, i32 4, i32 4)
   return sub_group_reserve_write_pipe(Pipe, 4U);
 }
 
 void test_call_commit_read(pipe int Pipe) {
   reserve_id_t id = my_mystery_function();
-// CHECK: call void @_Z26sub_group_commit_read_pipePU3AS110ocl_pipe_t16ocl_reserve_id_ti(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 4)
+// CHECK: call void @_Z26sub_group_commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 4, i32 4)
   sub_group_commit_read_pipe(Pipe, id);
 }
 
 void test_call_commit_write(pipe int Pipe) {
   reserve_id_t id = my_mystery_function();
-// CHECK: call void @_Z27sub_group_commit_write_pipePU3AS110ocl_pipe_t16ocl_reserve_id_ti(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 4)
+// CHECK: call void @_Z27sub_group_commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 4, i32 4)
   sub_group_commit_write_pipe(Pipe, id);
 }

--- a/test/OpenCL/OpenCL20/Pipes/call_wg_pipes.cl
+++ b/test/OpenCL/OpenCL20/Pipes/call_wg_pipes.cl
@@ -3,23 +3,23 @@
 extern reserve_id_t my_mystery_function();
 
 reserve_id_t test_call_read_pipe(pipe int Pipe) {
-// CHECK: call %opencl.reserve_id_t* @_Z28work_group_reserve_read_pipePU3AS110ocl_pipe_tji(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 4, i32 4)
+// CHECK: call %opencl.reserve_id_t* @_Z28work_group_reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 4, i32 4, i32 4)
   return work_group_reserve_read_pipe(Pipe, 4U);
 }
 
 reserve_id_t test_call_write_pipe(pipe int Pipe) {
-// CHECK: call %opencl.reserve_id_t* @_Z29work_group_reserve_write_pipePU3AS110ocl_pipe_tji(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 4, i32 4)
+// CHECK: call %opencl.reserve_id_t* @_Z29work_group_reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i32 4, i32 4, i32 4)
   return work_group_reserve_write_pipe(Pipe, 4U);
 }
 
 void test_call_commit_read(pipe int Pipe) {
   reserve_id_t id = my_mystery_function();
-// CHECK: call void @_Z27work_group_commit_read_pipePU3AS110ocl_pipe_t16ocl_reserve_id_ti(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 4)
+// CHECK: call void @_Z27work_group_commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 4, i32 4)
   work_group_commit_read_pipe(Pipe, id);
 }
 
 void test_call_commit_write(pipe int Pipe) {
   reserve_id_t id = my_mystery_function();
-// CHECK: call void @_Z28work_group_commit_write_pipePU3AS110ocl_pipe_t16ocl_reserve_id_ti(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 4)
+// CHECK: call void @_Z28work_group_commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %{{.*}}, %opencl.reserve_id_t* %{{.*}}, i32 4, i32 4)
   work_group_commit_write_pipe(Pipe, id);
 }

--- a/test/OpenCL/OpenCL20/Pipes/call_write_pipe2.cl
+++ b/test/OpenCL/OpenCL20/Pipes/call_write_pipe2.cl
@@ -1,14 +1,14 @@
 // RUN: %clang_cc1 -O0 -cl-std=CL2.0 -emit-llvm %s -o - | FileCheck %s
 
 kernel void test_write_pipe(global int *Src, write_only pipe int Pipe) {
-  // CHECK: call i32 @_Z10write_pipePU3AS110ocl_pipe_tPU3AS4vi(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4)
+  // CHECK: call i32 @_Z10write_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4, i32 4)
   write_pipe (Pipe, Src);
 }
 
 kernel void test_twice_write_pipe(global int *Src, write_only pipe int Pipe) {
-  // CHECK: call i32 @_Z10write_pipePU3AS110ocl_pipe_tPU3AS4vi(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4)
+  // CHECK: call i32 @_Z10write_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4, i32 4)
   write_pipe (Pipe, Src);
-  // CHECK: call i32 @_Z10write_pipePU3AS110ocl_pipe_tPU3AS4vi(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4)
+  // CHECK: call i32 @_Z10write_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4, i32 4)
   write_pipe (Pipe, Src);
 }
 

--- a/test/OpenCL/OpenCL20/Pipes/call_write_pipe4.cl
+++ b/test/OpenCL/OpenCL20/Pipes/call_write_pipe4.cl
@@ -3,7 +3,7 @@
 reserve_id_t my_mystery_function();
 
 kernel void test_write_pipe(global int *Src, write_only pipe int Pipe) {
-  // CHECK: call i32 @_Z10write_pipePU3AS110ocl_pipe_t16ocl_reserve_id_tjPU3AS4vi(%opencl.pipe_t addrspace(1)* {{.*}}, %opencl.reserve_id_t* {{.*}}, i32 0, i8 addrspace(4)* {{.*}}, i32 4)
+  // CHECK: call i32 @_Z10write_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* {{.*}}, %opencl.reserve_id_t* {{.*}}, i32 0, i8 addrspace(4)* {{.*}}, i32 4, i32 4)
   reserve_id_t ID = my_mystery_function();
   write_pipe (Pipe, ID, 0U, Src);
 }

--- a/test/OpenCL/OpenCL20/Pipes/pipe_user_type.cl
+++ b/test/OpenCL/OpenCL20/Pipes/pipe_user_type.cl
@@ -12,11 +12,11 @@ kernel void test_reserved_read_pipe(global struct Person *SDst,
                                     read_only pipe struct Person SPipe,
                                     read_only pipe int IPipe) {
   read_pipe (SPipe, SDst);
-  // CHECK64: call i32 @_Z9read_pipePU3AS110ocl_pipe_tPU3AS4vi(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 16)
-  // CHECK32: call i32 @_Z9read_pipePU3AS110ocl_pipe_tPU3AS4vi(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 12)
+  // CHECK64: call i32 @_Z9read_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 16, i32 {{[1-9]+}})
+  // CHECK32: call i32 @_Z9read_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 12, i32 {{[1-9]+}})
   read_pipe (IPipe, IDst);
-  // CHECK64: call i32 @_Z9read_pipePU3AS110ocl_pipe_tPU3AS4vi(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4)
+  // CHECK64: call i32 @_Z9read_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 4, i32 {{[1-9]+}})
   read_pipe (SPipe, SDst);
-  // CHECK64: call i32 @_Z9read_pipePU3AS110ocl_pipe_tPU3AS4vi(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 16)
-  // CHECK32: call i32 @_Z9read_pipePU3AS110ocl_pipe_tPU3AS4vi(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 12)
+  // CHECK64: call i32 @_Z9read_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 16, i32 {{[1-9]+}})
+  // CHECK32: call i32 @_Z9read_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)* %{{.*}}, i8 addrspace(4)* %{{.*}}, i32 12, i32 {{[1-9]+}})
 }


### PR DESCRIPTION
[OpenCL][Pipes] Fixes to pipes implementation according to
SPIR 2.0 provisional specification:
- [CodeGenOpenCL] Add i32 literal argument meaning pipe element
   alignment to the built-ins accepting pipe as an argument,
   it was missing thus violating SPIR 2.0 spec.
- Change mangling of pipe builtins (aligned with SPIR 2.0 spec):
   encode uint built-in arguments and two additional literal i32
   arguments (required by SPIR 2.0 spec) as unsigned int (as 'j').
- Change mangling of pipe and reserve_id_t opaque structs:
      ocl_pipe_t       -> ocl_pipe
      ocl_reserve_id_t -> ocl_reserveid

This patch works together with a patch to Khronos/SPIRV-LLVM khronos/spirv-3.6.1 branch:
"[Reader] Fixes to mangling of pipe built-ins (align with SPIR 2.0 provisional specification)."
