### PR TITLE
[SPIR-V] Ignore optimization level provided by user for SPIR-V.

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -74,8 +74,6 @@ using namespace llvm::opt;
 static unsigned getOptimizationLevel(ArgList &Args, InputKind IK,
                                      DiagnosticsEngine &Diags) {
   unsigned DefaultOpt = 0;
-  if (IK == IK_OpenCL && (!Args.hasArg(OPT_cl_opt_disable) && !Args.hasArg(OPT_emit_spirv)))
-    DefaultOpt = 2;
 
   if (Arg *A = Args.getLastArg(options::OPT_O_Group)) {
     if (A->getOption().matches(options::OPT_O0))
@@ -349,6 +347,12 @@ static bool ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args, InputKind IK,
   unsigned OptimizationLevel = getOptimizationLevel(Args, IK, Diags);
   // TODO: This could be done in Driver
   unsigned MaxOptLevel = 3;
+  if (IK == IK_OpenCL) {
+    if (Args.hasArg(OPT_emit_spirv) || Args.hasArg(OPT_cl_opt_disable)) {
+      MaxOptLevel = 0;
+    }
+  }
+
   if (OptimizationLevel > MaxOptLevel) {
     // If the optimization level is not supported, fall back on the default
     // optimization

--- a/test/CodeGenOpenCL/address-spaces.cl
+++ b/test/CodeGenOpenCL/address-spaces.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -ffake-address-space-map -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -O2 -ffake-address-space-map -emit-llvm -o - | FileCheck %s
 
 void f__p(__private int *arg) { }
 // CHECK: i32* nocapture %arg

--- a/test/CodeGenOpenCL/half.cl
+++ b/test/CodeGenOpenCL/half.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -O2 -emit-llvm -o - | FileCheck %s
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 

--- a/test/CodeGenOpenCL/single-precision-constant.cl
+++ b/test/CodeGenOpenCL/single-precision-constant.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -cl-single-precision-constant -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -O2 -cl-single-precision-constant -emit-llvm -o - | FileCheck %s
 
 float fn(float f) {
   // CHECK: tail call float @llvm.fmuladd.f32(float %f, float 2.000000e+00, float 1.000000e+00)

--- a/test/CodeGenOpenCL/spir-calling-conv.cl
+++ b/test/CodeGenOpenCL/spir-calling-conv.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple "spir-unknown-unknown" -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -O2 -triple "spir-unknown-unknown" -emit-llvm -o - | FileCheck %s
 
 int get_dummy_id(int D);
 

--- a/test/CodeGenOpenCL/spir/spir32_target.cl
+++ b/test/CodeGenOpenCL/spir/spir32_target.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple "spir-unknown-unknown" -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -O2 -triple "spir-unknown-unknown" -emit-llvm -o - | FileCheck %s
 
 // CHECK: target triple = "spir-unknown-unknown"
 

--- a/test/CodeGenOpenCL/spir/spir64_target.cl
+++ b/test/CodeGenOpenCL/spir/spir64_target.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple "spir64-unknown-unknown" -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -O2 -triple "spir64-unknown-unknown" -emit-llvm -o - | FileCheck %s
 
 // CHECK: target triple = "spir64-unknown-unknown"
 

--- a/test/CodeGenOpenCL/spir32_target.cl
+++ b/test/CodeGenOpenCL/spir32_target.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple "spir-unknown-unknown" -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -O2 -triple "spir-unknown-unknown" -emit-llvm -o - | FileCheck %s
 
 // CHECK: target triple = "spir-unknown-unknown"
 

--- a/test/CodeGenOpenCL/spir64_target.cl
+++ b/test/CodeGenOpenCL/spir64_target.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple "spir64-unknown-unknown" -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -O2 -triple "spir64-unknown-unknown" -emit-llvm -o - | FileCheck %s
 
 // CHECK: target triple = "spir64-unknown-unknown"
 

--- a/test/Driver/spirv-O.cl
+++ b/test/Driver/spirv-O.cl
@@ -1,0 +1,2 @@
+// RUN: %clang -cc1 -cl-std=CL1.2 -triple=spir-unknown-unknown -O1 -x cl -emit-spirv %s -o /dev/null %s 2>&1 | FileCheck %s
+// CHECK: warning: optimization level '-O1' is not supported; using '-O0' instead


### PR DESCRIPTION
Optimizing source code is not allowed before translation to SPIR-V
to preserve original code structure and semantic information.
Added warning in of using -O option with optimization level higher than 0.

This patch also sets default optimization level for OpenCL code to 0.
