### PR TITLE
[OpenCL] Complete image types support.

### DIFF
--- a/include/clang/AST/ASTContext.h
+++ b/include/clang/AST/ASTContext.h
@@ -811,11 +811,9 @@ public:
   CanQualType PseudoObjectTy, ARCUnbridgedCastTy;
   CanQualType ObjCBuiltinIdTy, ObjCBuiltinClassTy, ObjCBuiltinSelTy;
   CanQualType ObjCBuiltinBoolTy;
-  CanQualType OCLImage1dTy, OCLImage1dArrayTy, OCLImage1dBufferTy;
-  CanQualType OCLImage2dTy, OCLImage2dArrayTy;
-  CanQualType OCLImage2dDepthTy, OCLImage2dMSAATy, OCLImage2dMSAADepthTy;
-  CanQualType OCLImage2dArrayMSAADepthTy, OCLImage2dArrayMSAATy, OCLImage2dArrayDepthTy;
-  CanQualType OCLImage3dTy;
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  CanQualType SingletonId;
+#include "clang/Basic/OpenCLImageTypes.def"
   CanQualType OCLSamplerTy, OCLEventTy;
   CanQualType OCLQueueTy, OCLCLKEventTy, OCLReserveIdTy;
 

--- a/include/clang/AST/BuiltinTypes.def
+++ b/include/clang/AST/BuiltinTypes.def
@@ -154,21 +154,6 @@ BUILTIN_TYPE(ObjCClass, ObjCBuiltinClassTy)
 // type is a typedef of a PointerType to this.
 BUILTIN_TYPE(ObjCSel, ObjCBuiltinSelTy)
 
-// OpenCL image types.
-BUILTIN_TYPE(OCLImage1d, OCLImage1dTy)
-BUILTIN_TYPE(OCLImage1dArray, OCLImage1dArrayTy)
-BUILTIN_TYPE(OCLImage1dBuffer, OCLImage1dBufferTy)
-BUILTIN_TYPE(OCLImage2d, OCLImage2dTy)
-BUILTIN_TYPE(OCLImage2dArray, OCLImage2dArrayTy)
-BUILTIN_TYPE(OCLImage3d, OCLImage3dTy)
-
-BUILTIN_TYPE(OCLImage2dDepth,          OCLImage2dDepthTy)
-BUILTIN_TYPE(OCLImage2dMSAA,           OCLImage2dMSAATy)
-BUILTIN_TYPE(OCLImage2dMSAADepth,      OCLImage2dMSAADepthTy)
-BUILTIN_TYPE(OCLImage2dArrayMSAADepth, OCLImage2dArrayMSAADepthTy)
-BUILTIN_TYPE(OCLImage2dArrayMSAA,      OCLImage2dArrayMSAATy)
-BUILTIN_TYPE(OCLImage2dArrayDepth,     OCLImage2dArrayDepthTy)
-
 // OpenCL sampler_t.
 BUILTIN_TYPE(OCLSampler, OCLSamplerTy)
 

--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -1602,23 +1602,11 @@ public:
   bool isNullPtrType() const;                   // C++0x nullptr_t
   bool isAtomicType() const;                    // C11 _Atomic()
 
-  bool isImage1dT() const;                      // OpenCL image1d_t
-  bool isImage1dArrayT() const;                 // OpenCL image1d_array_t
-  bool isImage1dBufferT() const;                // OpenCL image1d_buffer_t
-  bool isImage2dT() const;                      // OpenCL image2d_t
-  bool isImage2dArrayT() const;                 // OpenCL image2d_array_t
-  bool isImage3dT() const;                      // OpenCL image3d_t
-
-  bool isImage2dDepthT() const;
-  bool isImage2dMSAAT() const;
-  bool isImage2dMSAADepthT() const;
-  bool isImage2dArrayMSAADepthT() const;
-  bool isImage2dArrayMSAAT() const;
-  bool isImage2dArrayDepthT() const;
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  bool is##Id##Type() const;
+#include "clang/Basic/OpenCLImageTypes.def"
 
   bool isImageType() const;                     // Any OpenCL image type
-  bool isImageDepthType() const;                // Any OpenCL depth image type
-  bool isImageMSAAType() const;                 // Any OpenCL msaa image type
 
   bool isSamplerT() const;                      // OpenCL sampler_t
   bool isEventT() const;                        // OpenCL event_t
@@ -1882,6 +1870,10 @@ template <> inline const Class##Type *Type::castAs() const { \
 class BuiltinType : public Type {
 public:
   enum Kind {
+// OpenCL image types
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) Id,
+#include "clang/Basic/OpenCLImageTypes.def"
+// All other builtin types
 #define BUILTIN_TYPE(Id, SingletonId) Id,
 #define LAST_BUILTIN_TYPE(Id) LastKind = Id
 #include "clang/AST/BuiltinTypes.def"
@@ -5107,53 +5099,11 @@ inline bool Type::isObjCBuiltinType() const {
   return isObjCIdType() || isObjCClassType() || isObjCSelType();
 }
 
-inline bool Type::isImage1dT() const {
-  return isSpecificBuiltinType(BuiltinType::OCLImage1d);
-}
-
-inline bool Type::isImage1dArrayT() const {
-  return isSpecificBuiltinType(BuiltinType::OCLImage1dArray);
-}
-
-inline bool Type::isImage1dBufferT() const {
-  return isSpecificBuiltinType(BuiltinType::OCLImage1dBuffer);
-}
-
-inline bool Type::isImage2dT() const {
-  return isSpecificBuiltinType(BuiltinType::OCLImage2d);
-}
-
-inline bool Type::isImage2dArrayT() const {
-  return isSpecificBuiltinType(BuiltinType::OCLImage2dArray);
-}
-
-inline bool Type::isImage3dT() const {
-  return isSpecificBuiltinType(BuiltinType::OCLImage3d);
-}
-
-inline bool Type::isImage2dDepthT() const {
-  return isSpecificBuiltinType(BuiltinType::OCLImage2dDepth);
-}
-
-inline bool Type::isImage2dMSAAT() const {
-  return isSpecificBuiltinType(BuiltinType::OCLImage2dMSAA);
-}
-
-inline bool Type::isImage2dMSAADepthT() const {
-  return isSpecificBuiltinType(BuiltinType::OCLImage2dMSAADepth);
-}
-
-inline bool Type::isImage2dArrayMSAADepthT() const {
-  return isSpecificBuiltinType(BuiltinType::OCLImage2dArrayMSAADepth);
-}
-
-inline bool Type::isImage2dArrayMSAAT() const {
-  return isSpecificBuiltinType(BuiltinType::OCLImage2dArrayMSAA);
-}
-
-inline bool Type::isImage2dArrayDepthT() const {
-  return isSpecificBuiltinType(BuiltinType::OCLImage2dArrayDepth);
-}
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  inline bool Type::is##Id##Type() const { \
+    return isSpecificBuiltinType(BuiltinType::Id); \
+  }
+#include "clang/Basic/OpenCLImageTypes.def"
 
 inline bool Type::isSamplerT() const {
   return isSpecificBuiltinType(BuiltinType::OCLSampler);
@@ -5168,21 +5118,10 @@ inline bool Type::isReserveIdT() const {
 }
 
 inline bool Type::isImageType() const {
-  return isImage3dT() ||
-         isImage2dT() || isImage2dArrayT() ||
-         isImage2dDepthT() || isImage2dArrayDepthT() ||
-         isImage2dMSAAT() || isImage2dArrayMSAAT() ||
-         isImage2dMSAADepthT() || isImage2dArrayMSAADepthT() ||
-         isImage1dT() || isImage1dArrayT() || isImage1dBufferT();
-}
-
-inline bool Type::isImageDepthType() const {
-  return isImage2dDepthT() || isImage2dArrayDepthT();
-}
-
-inline bool Type::isImageMSAAType() const {
-  return isImage2dMSAAT() || isImage2dArrayMSAAT() ||
-         isImage2dMSAADepthT() || isImage2dArrayMSAADepthT();
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) is##Id##Type() ||
+  return
+#include "clang/Basic/OpenCLImageTypes.def"
+      0; // end boolean or operation
 }
 
 inline bool Type::isExecType() const {

--- a/include/clang/Basic/OpenCLImageTypes.def
+++ b/include/clang/Basic/OpenCLImageTypes.def
@@ -1,0 +1,82 @@
+//===-- OpenCLImageTypes.def - Metadata about BuiltinTypes ------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//  This file extends builtin types database with OpenCL image singleton types.
+//  Custom code should define one of those two macros:
+//    GENERIC_IMAGE_TYPE(Type, Id) - a generic image with its Id without an
+//      access type
+//    IMAGE_TYPE(Type, Id, SingletonId, AccessType, CGSuffix) - an image type
+//      with given ID, singleton ID access type and a codegen suffix
+
+#ifdef GENERIC_IMAGE_TYPE
+
+#define IMAGE_READ_TYPE(Type, Id) GENERIC_IMAGE_TYPE(Type, Id)
+#define IMAGE_WRITE_TYPE(Type, Id)
+#define IMAGE_READ_WRITE_TYPE(Type, Id)
+
+#else
+
+#ifndef IMAGE_READ_TYPE
+#define IMAGE_READ_TYPE(Type, Id) \
+          IMAGE_TYPE(Type, Id##RO, Id##ROTy,  read_only, ro)
+#endif
+#ifndef IMAGE_WRITE_TYPE
+#define IMAGE_WRITE_TYPE(Type, Id) \
+          IMAGE_TYPE(Type, Id##WO, Id##WOTy, write_only, wo)
+#endif
+#ifndef IMAGE_READ_WRITE_TYPE
+#define IMAGE_READ_WRITE_TYPE(Type, Id) \
+          IMAGE_TYPE(Type, Id##RW, Id##RWTy, read_write, rw)
+#endif
+
+#endif
+
+IMAGE_READ_TYPE(image1d, OCLImage1d)
+IMAGE_READ_TYPE(image1d_array, OCLImage1dArray)
+IMAGE_READ_TYPE(image1d_buffer, OCLImage1dBuffer)
+IMAGE_READ_TYPE(image2d, OCLImage2d)
+IMAGE_READ_TYPE(image2d_array, OCLImage2dArray)
+IMAGE_READ_TYPE(image2d_depth, OCLImage2dDepth)
+IMAGE_READ_TYPE(image2d_array_depth, OCLImage2dArrayDepth)
+IMAGE_READ_TYPE(image2d_msaa, OCLImage2dMSAA)
+IMAGE_READ_TYPE(image2d_array_msaa, OCLImage2dArrayMSAA)
+IMAGE_READ_TYPE(image2d_msaa_depth, OCLImage2dMSAADepth)
+IMAGE_READ_TYPE(image2d_array_msaa_depth, OCLImage2dArrayMSAADepth)
+IMAGE_READ_TYPE(image3d, OCLImage3d)
+
+IMAGE_WRITE_TYPE(image1d, OCLImage1d)
+IMAGE_WRITE_TYPE(image1d_array, OCLImage1dArray)
+IMAGE_WRITE_TYPE(image1d_buffer, OCLImage1dBuffer)
+IMAGE_WRITE_TYPE(image2d, OCLImage2d)
+IMAGE_WRITE_TYPE(image2d_array, OCLImage2dArray)
+IMAGE_WRITE_TYPE(image2d_depth, OCLImage2dDepth)
+IMAGE_WRITE_TYPE(image2d_array_depth, OCLImage2dArrayDepth)
+IMAGE_WRITE_TYPE(image2d_msaa, OCLImage2dMSAA)
+IMAGE_WRITE_TYPE(image2d_array_msaa, OCLImage2dArrayMSAA)
+IMAGE_WRITE_TYPE(image2d_msaa_depth, OCLImage2dMSAADepth)
+IMAGE_WRITE_TYPE(image2d_array_msaa_depth, OCLImage2dArrayMSAADepth)
+IMAGE_WRITE_TYPE(image3d, OCLImage3d)
+
+IMAGE_READ_WRITE_TYPE(image1d, OCLImage1d)
+IMAGE_READ_WRITE_TYPE(image1d_array, OCLImage1dArray)
+IMAGE_READ_WRITE_TYPE(image1d_buffer, OCLImage1dBuffer)
+IMAGE_READ_WRITE_TYPE(image2d, OCLImage2d)
+IMAGE_READ_WRITE_TYPE(image2d_array, OCLImage2dArray)
+IMAGE_READ_WRITE_TYPE(image2d_depth, OCLImage2dDepth)
+IMAGE_READ_WRITE_TYPE(image2d_array_depth, OCLImage2dArrayDepth)
+IMAGE_READ_WRITE_TYPE(image2d_msaa, OCLImage2dMSAA)
+IMAGE_READ_WRITE_TYPE(image2d_array_msaa, OCLImage2dArrayMSAA)
+IMAGE_READ_WRITE_TYPE(image2d_msaa_depth, OCLImage2dMSAADepth)
+IMAGE_READ_WRITE_TYPE(image2d_array_msaa_depth, OCLImage2dArrayMSAADepth)
+IMAGE_READ_WRITE_TYPE(image3d, OCLImage3d)
+
+#undef IMAGE_TYPE
+#undef GENERIC_IMAGE_TYPE
+#undef IMAGE_READ_TYPE
+#undef IMAGE_WRITE_TYPE
+#undef IMAGE_READ_WRITE_TYPE

--- a/include/clang/Basic/Specifiers.h
+++ b/include/clang/Basic/Specifiers.h
@@ -68,26 +68,16 @@ namespace clang {
     TST_decltype_auto,    // C++1y decltype(auto)
     TST_unknown_anytype,  // __unknown_anytype extension
     TST_atomic,           // C11 _Atomic
-    TST_image1d_t,        // OpenCL image1d_t
-    TST_image1d_array_t,  // OpenCL image1d_array_t
-    TST_image1d_buffer_t, // OpenCL image1d_buffer_t
-    TST_image2d_t,        // OpenCL image2d_t
-    TST_image2d_array_t,  // OpenCL image2d_array_t
-    TST_image3d_t,        // OpenCL image3d_t
-    TST_image2d_depth_t,  // OpenCL image2d_depth_t
-    TST_image2d_msaa_t,   // OpenCL image2d_msaa_t
-    TST_image2d_msaa_depth_t, // OpenCL image2d_msaa_depth_t
-    TST_image2d_array_msaa_depth_t, // OpenCL image2d_array_msaa_depth_t
-    TST_image2d_array_msaa_t, // OpenCL image2d_array_msaa_t
-    TST_image2d_array_depth_t, // OpenCL image2d_array_depth_t
+#define GENERIC_IMAGE_TYPE(ImgType, Id) TST_##ImgType##_t, // OpenCL image types
+#include "clang/Basic/OpenCLImageTypes.def"
     TST_sampler_t,        // OpenCL sampler_t
     TST_event_t,          // OpenCL event_t
     TST_queue_t,          // OpenCL queue_t
     TST_clk_event_t,      // OpenCL clk_event_t
     TST_reserve_id_t,     // OpenCL reserve_id_t
-    TST_error         // erroneous type
+    TST_error // erroneous type
   };
-  
+
   /// \brief Structure that packs information about the type specifiers that
   /// were written in a particular type specifier sequence.
   struct WrittenBuiltinSpecs {

--- a/include/clang/Basic/TokenKinds.def
+++ b/include/clang/Basic/TokenKinds.def
@@ -488,23 +488,12 @@ ALIAS("write_only", __write_only    , KEYOPENCL)
 ALIAS("read_write", __read_write    , KEYOPENCL)
 // OpenCL builtins
 KEYWORD(__builtin_astype            , KEYOPENCL)
-KEYWORD(image1d_t                   , KEYOPENCL)
-KEYWORD(image1d_array_t             , KEYOPENCL)
-KEYWORD(image1d_buffer_t            , KEYOPENCL)
-KEYWORD(image2d_t                   , KEYOPENCL)
-KEYWORD(image2d_array_t             , KEYOPENCL)
-KEYWORD(image3d_t                   , KEYOPENCL)
-
-KEYWORD(image2d_depth_t             , KEYOPENCL)
-KEYWORD(image2d_msaa_t              , KEYOPENCL)
-KEYWORD(image2d_msaa_depth_t        , KEYOPENCL)
-KEYWORD(image2d_array_msaa_depth_t  , KEYOPENCL)
-KEYWORD(image2d_array_msaa_t        , KEYOPENCL)
-KEYWORD(image2d_array_depth_t       , KEYOPENCL)
+KEYWORD(vec_step                    , KEYOPENCL|KEYALTIVEC)
+#define GENERIC_IMAGE_TYPE(ImgType, Id) KEYWORD(ImgType##_t, KEYOPENCL)
+#include "clang/Basic/OpenCLImageTypes.def"
 
 KEYWORD(sampler_t                   , KEYOPENCL)
 KEYWORD(event_t                     , KEYOPENCL)
-KEYWORD(vec_step                    , KEYOPENCL|KEYALTIVEC)
 
 // OpenCL 2.0
 KEYWORD(queue_t                     , KEYOPENCL)

--- a/include/clang/Sema/DeclSpec.h
+++ b/include/clang/Sema/DeclSpec.h
@@ -302,18 +302,9 @@ public:
   static const TST TST_auto = clang::TST_auto;
   static const TST TST_unknown_anytype = clang::TST_unknown_anytype;
   static const TST TST_atomic = clang::TST_atomic;
-  static const TST TST_image1d_t = clang::TST_image1d_t;
-  static const TST TST_image1d_array_t = clang::TST_image1d_array_t;
-  static const TST TST_image1d_buffer_t = clang::TST_image1d_buffer_t;
-  static const TST TST_image2d_t = clang::TST_image2d_t;
-  static const TST TST_image2d_array_t = clang::TST_image2d_array_t;
-  static const TST TST_image2d_depth_t = clang::TST_image2d_depth_t;
-  static const TST TST_image2d_array_depth_t = clang::TST_image2d_array_depth_t;
-  static const TST TST_image2d_msaa_t = clang::TST_image2d_msaa_t;
-  static const TST TST_image2d_array_msaa_t = clang::TST_image2d_array_msaa_t;
-  static const TST TST_image2d_msaa_depth_t = clang::TST_image2d_msaa_depth_t;
-  static const TST TST_image2d_array_msaa_depth_t = clang::TST_image2d_array_msaa_depth_t;
-  static const TST TST_image3d_t = clang::TST_image3d_t;
+#define GENERIC_IMAGE_TYPE(ImgType, Id) \
+  static const TST TST_##ImgType##_t = clang::TST_##ImgType##_t;
+#include "clang/Basic/OpenCLImageTypes.def"
   static const TST TST_sampler_t = clang::TST_sampler_t;
   static const TST TST_event_t = clang::TST_event_t;
   static const TST TST_queue_t = clang::TST_queue_t;

--- a/include/clang/Serialization/ASTBitCodes.h
+++ b/include/clang/Serialization/ASTBitCodes.h
@@ -749,40 +749,20 @@ namespace clang {
       PREDEF_TYPE_VA_LIST_TAG = 36,
       /// \brief The placeholder type for builtin functions.
       PREDEF_TYPE_BUILTIN_FN = 37,
-      /// \brief OpenCL 1d image type.
-      PREDEF_TYPE_IMAGE1D_ID    = 38,
-      /// \brief OpenCL 1d image array type.
-      PREDEF_TYPE_IMAGE1D_ARR_ID = 39,
-      /// \brief OpenCL 1d image buffer type.
-      PREDEF_TYPE_IMAGE1D_BUFF_ID = 40,
-      /// \brief OpenCL 2d image type.
-      PREDEF_TYPE_IMAGE2D_ID    = 41,
-      /// \brief OpenCL 2d image array type.
-      PREDEF_TYPE_IMAGE2D_ARR_ID = 42,
-      /// \brief OpenCL 3d image type.
-      PREDEF_TYPE_IMAGE3D_ID    = 43,
-      /// \brief OpenCL 2d depth image type.
-      PREDEF_TYPE_IMAGE2DDepth_ID = 44,
-      /// \brief OpenCL 2d msaa image type.
-      PREDEF_TYPE_IMAGE2DMSAA_ID = 45,
-      /// \brief OpenCL 2d msaa depth type.
-      PREDEF_TYPE_IMAGE2DMSAADepth_ID = 46,
-      /// \brief OpenCL 2d array msaa depth type.
-      PREDEF_TYPE_IMAGE2DArrayMSAADepth_ID = 47,
-      /// \brief OpenCL 2d array msaa type.
-      PREDEF_TYPE_IMAGE2DArrayMSAA_ID = 48,
-      /// \brief OpenCL 2d array depth type.
-      PREDEF_TYPE_IMAGE2DArrayDepth_ID = 49,
       /// \brief OpenCL sampler type.
-      PREDEF_TYPE_SAMPLER_ID    = 50,
+      PREDEF_TYPE_SAMPLER_ID    = 38,
       /// \brief OpenCL event type.
-      PREDEF_TYPE_EVENT_ID      = 51,
+      PREDEF_TYPE_EVENT_ID      = 39,
       /// \brief OpenCL queue type.
-      PREDEF_TYPE_QUEUE_ID      = 52,
+      PREDEF_TYPE_QUEUE_ID      = 40,
       /// \brief OpenCL clk_event type.
-      PREDEF_TYPE_CLK_EVENT_ID  = 54,
+      PREDEF_TYPE_CLK_EVENT_ID  = 41,
       /// \brief OpenCL reserve_id type.
-      PREDEF_TYPE_RESERVE_ID_ID  = 55
+      PREDEF_TYPE_RESERVE_ID_ID  = 42,
+      /// \brief OpenCL image types with auto numeration
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+      PREDEF_TYPE_##Id##_ID,
+#include "clang/Basic/OpenCLImageTypes.def"
     };
 
     /// \brief The number of predefined type IDs that are reserved for

--- a/include/clang/module.modulemap
+++ b/include/clang/module.modulemap
@@ -43,6 +43,7 @@ module Clang_Basic {
   exclude header "Basic/DiagnosticOptions.def"
   exclude header "Basic/LangOptions.def"
   exclude header "Basic/OpenCLExtensions.def"
+  exclude header "Basic/OpenCLImageTypes.def"
   exclude header "Basic/OpenMPKinds.def"
   exclude header "Basic/OperatorKinds.def"
   exclude header "Basic/Sanitizers.def"

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1019,21 +1019,10 @@ void ASTContext::InitBuiltinTypes(const TargetInfo &Target) {
   InitBuiltinType(ObjCBuiltinClassTy, BuiltinType::ObjCClass);
   InitBuiltinType(ObjCBuiltinSelTy, BuiltinType::ObjCSel);
 
-  if (LangOpts.OpenCL) { 
-    InitBuiltinType(OCLImage1dTy, BuiltinType::OCLImage1d);
-    InitBuiltinType(OCLImage1dArrayTy, BuiltinType::OCLImage1dArray);
-    InitBuiltinType(OCLImage1dBufferTy, BuiltinType::OCLImage1dBuffer);
-    InitBuiltinType(OCLImage2dTy, BuiltinType::OCLImage2d);
-    InitBuiltinType(OCLImage2dArrayTy, BuiltinType::OCLImage2dArray);
-    InitBuiltinType(OCLImage3dTy, BuiltinType::OCLImage3d);
-
-    // MSAA Types
-    InitBuiltinType(OCLImage2dDepthTy,          BuiltinType::OCLImage2dDepth);
-    InitBuiltinType(OCLImage2dMSAATy,           BuiltinType::OCLImage2dMSAA);
-    InitBuiltinType(OCLImage2dMSAADepthTy,      BuiltinType::OCLImage2dMSAADepth);
-    InitBuiltinType(OCLImage2dArrayMSAADepthTy, BuiltinType::OCLImage2dArrayMSAADepth);
-    InitBuiltinType(OCLImage2dArrayMSAATy,      BuiltinType::OCLImage2dArrayMSAA);
-    InitBuiltinType(OCLImage2dArrayDepthTy,     BuiltinType::OCLImage2dArrayDepth);
+  if (LangOpts.OpenCL) {
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+    InitBuiltinType(SingletonId, BuiltinType::Id);
+#include "clang/Basic/OpenCLImageTypes.def"
 
     InitBuiltinType(OCLSamplerTy, BuiltinType::OCLSampler);
     InitBuiltinType(OCLEventTy, BuiltinType::OCLEvent);
@@ -1606,18 +1595,9 @@ TypeInfo ASTContext::getTypeInfoImpl(const Type *T) const {
       Align = Target->getIntAlign();
       break;
     case BuiltinType::OCLEvent:
-    case BuiltinType::OCLImage1d:
-    case BuiltinType::OCLImage1dArray:
-    case BuiltinType::OCLImage1dBuffer:
-    case BuiltinType::OCLImage2d:
-    case BuiltinType::OCLImage2dArray:
-    case BuiltinType::OCLImage3d:
-    case BuiltinType::OCLImage2dDepth:
-    case BuiltinType::OCLImage2dMSAA:
-    case BuiltinType::OCLImage2dMSAADepth:
-    case BuiltinType::OCLImage2dArrayMSAADepth:
-    case BuiltinType::OCLImage2dArrayMSAA:
-    case BuiltinType::OCLImage2dArrayDepth:
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+    case BuiltinType::Id:
+#include "clang/Basic/OpenCLImageTypes.def"
     case BuiltinType::OCLQueue:
     case BuiltinType::OCLCLKEvent:
     case BuiltinType::OCLReserveId:
@@ -5282,18 +5262,9 @@ static char getObjCEncodingForPrimitiveKind(const ASTContext *C,
       llvm_unreachable("@encoding ObjC primitive type");
 
     // OpenCL and placeholder types don't need @encodings.
-    case BuiltinType::OCLImage1d:
-    case BuiltinType::OCLImage1dArray:
-    case BuiltinType::OCLImage1dBuffer:
-    case BuiltinType::OCLImage2d:
-    case BuiltinType::OCLImage2dArray:
-    case BuiltinType::OCLImage3d:
-    case BuiltinType::OCLImage2dDepth:
-    case BuiltinType::OCLImage2dMSAA:
-    case BuiltinType::OCLImage2dMSAADepth:
-    case BuiltinType::OCLImage2dArrayMSAADepth:
-    case BuiltinType::OCLImage2dArrayMSAA:
-    case BuiltinType::OCLImage2dArrayDepth:
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+    case BuiltinType::Id:
+#include "clang/Basic/OpenCLImageTypes.def"
     case BuiltinType::OCLEvent:
     case BuiltinType::OCLSampler:
     case BuiltinType::OCLQueue:

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -1436,6 +1436,10 @@ QualType ASTNodeImporter::VisitType(const Type *T) {
 
 QualType ASTNodeImporter::VisitBuiltinType(const BuiltinType *T) {
   switch (T->getKind()) {
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  case BuiltinType::Id: \
+    return Importer.getToContext().SingletonId;
+#include "clang/Basic/OpenCLImageTypes.def"
 #define SHARED_SINGLETON_TYPE(Expansion)
 #define BUILTIN_TYPE(Id, SingletonId) \
   case BuiltinType::Id: return Importer.getToContext().SingletonId;

--- a/lib/AST/ItaniumMangle.cpp
+++ b/lib/AST/ItaniumMangle.cpp
@@ -1956,6 +1956,7 @@ void CXXNameMangler::mangleType(const BuiltinType *T) {
   //                 ::= Ds # char16_t
   //                 ::= Dn # std::nullptr_t (i.e., decltype(nullptr))
   //                 ::= u <source-name>    # vendor extended type
+  std::string type_name;
   switch (T->getKind()) {
   case BuiltinType::Void: Out << 'v'; break;
   case BuiltinType::Bool: Out << 'b'; break;
@@ -1991,18 +1992,12 @@ void CXXNameMangler::mangleType(const BuiltinType *T) {
   case BuiltinType::ObjCId: Out << "11objc_object"; break;
   case BuiltinType::ObjCClass: Out << "10objc_class"; break;
   case BuiltinType::ObjCSel: Out << "13objc_selector"; break;
-  case BuiltinType::OCLImage1d: Out << "11ocl_image1d"; break;
-  case BuiltinType::OCLImage1dArray: Out << "16ocl_image1darray"; break;
-  case BuiltinType::OCLImage1dBuffer: Out << "17ocl_image1dbuffer"; break;
-  case BuiltinType::OCLImage2d: Out << "11ocl_image2d"; break;
-  case BuiltinType::OCLImage2dArray: Out << "16ocl_image2darray"; break;
-  case BuiltinType::OCLImage2dDepth: Out << "16ocl_image2ddepth"; break;
-  case BuiltinType::OCLImage2dArrayDepth: Out << "21ocl_image2darraydepth"; break;
-  case BuiltinType::OCLImage2dMSAA: Out << "15ocl_image2dmsaa"; break;
-  case BuiltinType::OCLImage2dArrayMSAA: Out << "20ocl_image2darraymsaa"; break;
-  case BuiltinType::OCLImage2dMSAADepth: Out << "20ocl_image2dmsaadepth"; break;
-  case BuiltinType::OCLImage2dArrayMSAADepth: Out << "25ocl_image2darraymsaadepth"; break;
-  case BuiltinType::OCLImage3d: Out << "11ocl_image3d"; break;
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  case BuiltinType::Id: \
+    type_name = "ocl_" #ImgType "_" #Suffix; \
+    Out << type_name.size() << type_name; \
+    break;
+#include "clang/Basic/OpenCLImageTypes.def"
   case BuiltinType::OCLSampler: Out << "11ocl_sampler"; break;
   case BuiltinType::OCLEvent: Out << "9ocl_event"; break;
   case BuiltinType::OCLQueue: Out << "9ocl_queue"; break;

--- a/lib/AST/MicrosoftMangle.cpp
+++ b/lib/AST/MicrosoftMangle.cpp
@@ -1501,18 +1501,11 @@ void MicrosoftCXXNameMangler::mangleType(const BuiltinType *T,
   case BuiltinType::ObjCClass: Out << "PAUobjc_class@@"; break;
   case BuiltinType::ObjCSel: Out << "PAUobjc_selector@@"; break;
 
-  case BuiltinType::OCLImage1d: Out << "PAUocl_image1d@@"; break;
-  case BuiltinType::OCLImage1dArray: Out << "PAUocl_image1darray@@"; break;
-  case BuiltinType::OCLImage1dBuffer: Out << "PAUocl_image1dbuffer@@"; break;
-  case BuiltinType::OCLImage2d: Out << "PAUocl_image2d@@"; break;
-  case BuiltinType::OCLImage2dArray: Out << "PAUocl_image2darray@@"; break;
-  case BuiltinType::OCLImage2dDepth: Out << "PAUocl_image2ddepth@@"; break;
-  case BuiltinType::OCLImage2dArrayDepth: Out << "PAUocl_image2darraydepth@@"; break;
-  case BuiltinType::OCLImage2dMSAA: Out << "PAUocl_image2dmsaa@@"; break;
-  case BuiltinType::OCLImage2dArrayMSAA: Out << "PAUocl_image2darraymsaa@@"; break;
-  case BuiltinType::OCLImage2dMSAADepth: Out << "PAUocl_image2dmsaadepth@@"; break;
-  case BuiltinType::OCLImage2dArrayMSAADepth: Out << "PAUocl_image2darraymsaadepth@@"; break;
-  case BuiltinType::OCLImage3d: Out << "PAUocl_image3d@@"; break;
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  case BuiltinType::Id: \
+    Out << "PAUocl_" #ImgType "_" #Suffix "@@"; \
+    break;
+#include "clang/Basic/OpenCLImageTypes.def"
   case BuiltinType::OCLSampler: Out << "PAUocl_sampler@@"; break;
   case BuiltinType::OCLEvent: Out << "PAUocl_event@@"; break;
   case BuiltinType::OCLQueue: Out << "PAUocl_queue@@"; break;

--- a/lib/AST/NSAPI.cpp
+++ b/lib/AST/NSAPI.cpp
@@ -349,18 +349,9 @@ NSAPI::getNSNumberFactoryMethodKind(QualType T) const {
   case BuiltinType::ObjCClass:
   case BuiltinType::ObjCId:
   case BuiltinType::ObjCSel:
-  case BuiltinType::OCLImage1d:
-  case BuiltinType::OCLImage1dArray:
-  case BuiltinType::OCLImage1dBuffer:
-  case BuiltinType::OCLImage2d:
-  case BuiltinType::OCLImage2dArray:
-  case BuiltinType::OCLImage2dDepth:
-  case BuiltinType::OCLImage2dArrayDepth:
-  case BuiltinType::OCLImage2dMSAA:
-  case BuiltinType::OCLImage2dArrayMSAA:
-  case BuiltinType::OCLImage2dMSAADepth:
-  case BuiltinType::OCLImage2dArrayMSAADepth:
-  case BuiltinType::OCLImage3d:
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  case BuiltinType::Id:
+#include "clang/Basic/OpenCLImageTypes.def"
   case BuiltinType::OCLSampler:
   case BuiltinType::OCLEvent:
   case BuiltinType::OCLQueue:

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1576,18 +1576,10 @@ StringRef BuiltinType::getName(const PrintingPolicy &Policy) const {
   case ObjCId:            return "id";
   case ObjCClass:         return "Class";
   case ObjCSel:           return "SEL";
-  case OCLImage1d:        return "image1d_t";
-  case OCLImage1dArray:   return "image1d_array_t";
-  case OCLImage1dBuffer:  return "image1d_buffer_t";
-  case OCLImage2d:        return "image2d_t";
-  case OCLImage2dArray:   return "image2d_array_t";
-  case OCLImage3d:        return "image3d_t";
-  case OCLImage2dDepth:   return "image2d_depth_t";
-  case OCLImage2dMSAA:    return "image2d_msaa_t";
-  case OCLImage2dMSAADepth: return "image2d_msaa_depth_t";
-  case OCLImage2dArrayMSAADepth: return "image2d_array_msaa_depth_t";
-  case OCLImage2dArrayMSAA: return "image2d_array_msaa_t";
-  case OCLImage2dArrayDepth: return "image2d_array_depth_t";
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  case Id: \
+    return "__" #Access " " #ImgType "_t";
+#include "clang/Basic/OpenCLImageTypes.def"
   case OCLSampler:        return "sampler_t";
   case OCLEvent:          return "event_t";
   case OCLQueue:          return "queue_t";

--- a/lib/AST/TypeLoc.cpp
+++ b/lib/AST/TypeLoc.cpp
@@ -291,18 +291,9 @@ TypeSpecifierType BuiltinTypeLoc::getWrittenTypeSpec() const {
   case BuiltinType::ObjCId:
   case BuiltinType::ObjCClass:
   case BuiltinType::ObjCSel:
-  case BuiltinType::OCLImage1d:
-  case BuiltinType::OCLImage1dArray:
-  case BuiltinType::OCLImage1dBuffer:
-  case BuiltinType::OCLImage2d:
-  case BuiltinType::OCLImage2dArray:
-  case BuiltinType::OCLImage2dDepth:
-  case BuiltinType::OCLImage2dArrayDepth:
-  case BuiltinType::OCLImage2dMSAA:
-  case BuiltinType::OCLImage2dArrayMSAA:
-  case BuiltinType::OCLImage2dMSAADepth:
-  case BuiltinType::OCLImage2dArrayMSAADepth:
-  case BuiltinType::OCLImage3d:
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  case BuiltinType::Id:
+#include "clang/Basic/OpenCLImageTypes.def"
   case BuiltinType::OCLSampler:
   case BuiltinType::OCLEvent:
   case BuiltinType::OCLQueue:

--- a/lib/Analysis/PrintfFormatString.cpp
+++ b/lib/Analysis/PrintfFormatString.cpp
@@ -529,6 +529,9 @@ bool PrintfSpecifier::fixType(QualType QT, const LangOptions &LangOpt,
     // Various types which are non-trivial to correct.
     return false;
 
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  case BuiltinType::Id:
+#include "clang/Basic/OpenCLImageTypes.def"
 #define SIGNED_TYPE(Id, SingletonId)
 #define UNSIGNED_TYPE(Id, SingletonId)
 #define FLOATING_TYPE(Id, SingletonId)

--- a/lib/CodeGen/CGDebugInfo.cpp
+++ b/lib/CodeGen/CGDebugInfo.cpp
@@ -429,45 +429,11 @@ llvm::DIType CGDebugInfo::CreateType(const BuiltinType *BT) {
     return SelTy;
   }
 
-  case BuiltinType::OCLImage1d:
-    return getOrCreateStructPtrType("opencl_image1d_t", OCLImage1dDITy);
-  case BuiltinType::OCLImage1dArray:
-    return getOrCreateStructPtrType("opencl_image1d_array_t",
-                                    OCLImage1dArrayDITy);
-  case BuiltinType::OCLImage1dBuffer:
-    return getOrCreateStructPtrType("opencl_image1d_buffer_t",
-                                    OCLImage1dBufferDITy);
-  case BuiltinType::OCLImage2d:
-    return getOrCreateStructPtrType("opencl_image2d_t", OCLImage2dDITy);
-  case BuiltinType::OCLImage2dArray:
-    return getOrCreateStructPtrType("opencl_image2d_array_t",
-                                    OCLImage2dArrayDITy);
-  case BuiltinType::OCLImage3d:
-    return getOrCreateStructPtrType("opencl_image3d_t", OCLImage3dDITy);
-
-  case BuiltinType::OCLImage2dDepth:
-    return getOrCreateStructPtrType("opencl_image2d_depth_t",
-                                    OCLImage2dDepthDITy);
-
-  case BuiltinType::OCLImage2dMSAA:
-    return getOrCreateStructPtrType("opencl_image2d_msaa_t",
-                                    OCLImage2dMSAADITy);
-
-  case BuiltinType::OCLImage2dMSAADepth:
-    return getOrCreateStructPtrType("opencl_image2d_msaa_depth_t",
-                                    OCLImage2dMSAADepthDITy);
-  case BuiltinType::OCLImage2dArrayMSAADepth:
-    return getOrCreateStructPtrType("opencl_image2d_array_msaa_depth_t",
-                                    OCLImage2dArrayMSAADepthDITy);
-
-  case BuiltinType::OCLImage2dArrayMSAA:
-    return getOrCreateStructPtrType("opencl_image2d_array_msaa_t",
-                                    OCLImage2dArrayMSAADITy);
-
-  case BuiltinType::OCLImage2dArrayDepth:
-    return getOrCreateStructPtrType("opencl_image2d_array_depth_t",
-                                    OCLImage2dArrayDepthDITy);
-
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  case BuiltinType::Id: \
+    return getOrCreateStructPtrType("opencl_" #ImgType "_" #Suffix "_t", \
+                                    SingletonId);
+#include "clang/Basic/OpenCLImageTypes.def"
   case BuiltinType::OCLSampler:
     return DBuilder.createBasicType(
         "opencl_sampler_t", CGM.getContext().getTypeSize(BT),

--- a/lib/CodeGen/CGDebugInfo.h
+++ b/lib/CodeGen/CGDebugInfo.h
@@ -58,12 +58,9 @@ class CGDebugInfo {
   llvm::DIType ClassTy;
   llvm::DICompositeType ObjTy;
   llvm::DIType SelTy;
-  llvm::DIType OCLImage1dDITy, OCLImage1dArrayDITy, OCLImage1dBufferDITy;
-  llvm::DIType OCLImage2dDITy, OCLImage2dArrayDITy;
-  llvm::DIType OCLImage3dDITy;
-  llvm::DIType OCLImage2dDepthDITy, OCLImage2dMSAADITy, OCLImage2dMSAADepthDITy;
-  llvm::DIType OCLImage2dArrayMSAADepthDITy, OCLImage2dArrayMSAADITy;
-  llvm::DIType OCLImage2dArrayDepthDITy;
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  llvm::DIType SingletonId;
+#include "clang/Basic/OpenCLImageTypes.def"
 
   llvm::DIType OCLEventDITy;
   llvm::DIType OCLQueueDITy;

--- a/lib/CodeGen/CGOpenCLRuntime.cpp
+++ b/lib/CodeGen/CGOpenCLRuntime.cpp
@@ -40,42 +40,12 @@ llvm::Type *CGOpenCLRuntime::convertOpenCLSpecificType(const Type *T) {
   default: 
     llvm_unreachable("Unexpected opencl builtin type!");
     return nullptr;
-  case BuiltinType::OCLImage1d:
-    return llvm::PointerType::get(llvm::StructType::create(
-                           Ctx, "opencl.image1d_t"), ImgAddrSpc);
-  case BuiltinType::OCLImage1dArray:
-    return llvm::PointerType::get(llvm::StructType::create(
-                           Ctx, "opencl.image1d_array_t"), ImgAddrSpc);
-  case BuiltinType::OCLImage1dBuffer:
-    return llvm::PointerType::get(llvm::StructType::create(
-                           Ctx, "opencl.image1d_buffer_t"), ImgAddrSpc);
-  case BuiltinType::OCLImage2d:
-    return llvm::PointerType::get(llvm::StructType::create(
-                           Ctx, "opencl.image2d_t"), ImgAddrSpc);
-  case BuiltinType::OCLImage2dArray:
-    return llvm::PointerType::get(llvm::StructType::create(
-                           Ctx, "opencl.image2d_array_t"), ImgAddrSpc);
-  case BuiltinType::OCLImage2dDepth:
-    return llvm::PointerType::get(llvm::StructType::create(
-                           Ctx, "opencl.image2d_depth_t"), ImgAddrSpc);
-  case BuiltinType::OCLImage2dArrayDepth:
-    return llvm::PointerType::get(llvm::StructType::create(
-                           Ctx, "opencl.image2d_array_depth_t"), ImgAddrSpc);
-  case BuiltinType::OCLImage2dMSAA:
-    return llvm::PointerType::get(llvm::StructType::create(
-                           Ctx, "opencl.image2d_msaa_t"), ImgAddrSpc);
-  case BuiltinType::OCLImage2dArrayMSAA:
-    return llvm::PointerType::get(llvm::StructType::create(
-                           Ctx, "opencl.image2d_array_msaa_t"), ImgAddrSpc);
-  case BuiltinType::OCLImage2dMSAADepth:
-    return llvm::PointerType::get(llvm::StructType::create(
-                           Ctx, "opencl.image2d_msaa_depth_t"), ImgAddrSpc);
-  case BuiltinType::OCLImage2dArrayMSAADepth:
-    return llvm::PointerType::get(llvm::StructType::create(
-                           Ctx, "opencl.image2d_array_msaa_depth_t"), ImgAddrSpc);
-  case BuiltinType::OCLImage3d:
-    return llvm::PointerType::get(llvm::StructType::create(
-                           Ctx, "opencl.image3d_t"), ImgAddrSpc);
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  case BuiltinType::Id: \
+    return llvm::PointerType::get( \
+        llvm::StructType::create(Ctx, "opencl." #ImgType "_" #Suffix "_t"), \
+        ImgAddrSpc);
+#include "clang/Basic/OpenCLImageTypes.def"
   case BuiltinType::OCLSampler:
     if (CGM.getLangOpts().CLKeepSamplerType)
       return llvm::StructType::create(Ctx, llvm::IntegerType::get(Ctx, 32),

--- a/lib/CodeGen/CodeGenTypes.cpp
+++ b/lib/CodeGen/CodeGenTypes.cpp
@@ -382,18 +382,9 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
       ResultType = llvm::IntegerType::get(getLLVMContext(), 128);
       break;
 
-    case BuiltinType::OCLImage1d:
-    case BuiltinType::OCLImage1dArray:
-    case BuiltinType::OCLImage1dBuffer:
-    case BuiltinType::OCLImage2d:
-    case BuiltinType::OCLImage2dArray:
-    case BuiltinType::OCLImage3d:
-    case BuiltinType::OCLImage2dDepth:
-    case BuiltinType::OCLImage2dMSAA:
-    case BuiltinType::OCLImage2dMSAADepth:
-    case BuiltinType::OCLImage2dArrayMSAADepth:
-    case BuiltinType::OCLImage2dArrayMSAA:
-    case BuiltinType::OCLImage2dArrayDepth:
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+    case BuiltinType::Id:
+#include "clang/Basic/OpenCLImageTypes.def"
     case BuiltinType::OCLSampler:
     case BuiltinType::OCLEvent:
     case BuiltinType::OCLQueue:

--- a/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/lib/CodeGen/ItaniumCXXABI.cpp
@@ -2254,12 +2254,11 @@ static bool TypeInfoIsInStandardLibrary(const BuiltinType *Ty) {
     case BuiltinType::Char32:
     case BuiltinType::Int128:
     case BuiltinType::UInt128:
-    case BuiltinType::OCLImage1d:
-    case BuiltinType::OCLImage1dArray:
-    case BuiltinType::OCLImage1dBuffer:
-    case BuiltinType::OCLImage2d:
-    case BuiltinType::OCLImage2dArray:
-    case BuiltinType::OCLImage3d:
+      return true;
+
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+    case BuiltinType::Id:
+#include "clang/Basic/OpenCLImageTypes.def"
     case BuiltinType::OCLSampler:
     case BuiltinType::OCLEvent:
       return true;

--- a/lib/Index/USRGeneration.cpp
+++ b/lib/Index/USRGeneration.cpp
@@ -608,12 +608,9 @@ void USRGenerator::VisitType(QualType T) {
 #define PLACEHOLDER_TYPE(Id, SingletonId) case BuiltinType::Id:
 #include "clang/AST/BuiltinTypes.def"
         case BuiltinType::Dependent:
-        case BuiltinType::OCLImage1d:
-        case BuiltinType::OCLImage1dArray:
-        case BuiltinType::OCLImage1dBuffer:
-        case BuiltinType::OCLImage2d:
-        case BuiltinType::OCLImage2dArray:
-        case BuiltinType::OCLImage3d:
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+        case BuiltinType::Id:
+#include "clang/Basic/OpenCLImageTypes.def"
         case BuiltinType::OCLEvent:
         case BuiltinType::OCLSampler:
           IgnoreResults = true;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3206,55 +3206,6 @@ void Parser::ParseDeclarationSpecifiers(DeclSpec &DS,
     case tok::kw___bool:
       isInvalid = DS.SetTypeAltiVecBool(true, Loc, PrevSpec, DiagID, Policy);
       break;
-    case tok::kw_image1d_t:
-       isInvalid = DS.SetTypeSpecType(DeclSpec::TST_image1d_t, Loc,
-                                      PrevSpec, DiagID, Policy);
-      break;
-    case tok::kw_image1d_array_t:
-       isInvalid = DS.SetTypeSpecType(DeclSpec::TST_image1d_array_t, Loc,
-                                      PrevSpec, DiagID, Policy);
-      break;
-    case tok::kw_image1d_buffer_t:
-       isInvalid = DS.SetTypeSpecType(DeclSpec::TST_image1d_buffer_t, Loc,
-                                      PrevSpec, DiagID, Policy);
-      break;
-    case tok::kw_image2d_t:
-       isInvalid = DS.SetTypeSpecType(DeclSpec::TST_image2d_t, Loc,
-                                      PrevSpec, DiagID, Policy);
-      break;
-    case tok::kw_image2d_array_t:
-       isInvalid = DS.SetTypeSpecType(DeclSpec::TST_image2d_array_t, Loc,
-                                      PrevSpec, DiagID, Policy);
-      break;
-    case tok::kw_image3d_t:
-      isInvalid = DS.SetTypeSpecType(DeclSpec::TST_image3d_t, Loc,
-                                     PrevSpec, DiagID, Policy);
-      break;
-
-    case tok::kw_image2d_depth_t:
-      isInvalid = DS.SetTypeSpecType(DeclSpec::TST_image2d_depth_t, Loc,
-                                     PrevSpec, DiagID, Policy);
-      break;
-    case tok::kw_image2d_msaa_t:
-      isInvalid = DS.SetTypeSpecType(DeclSpec::TST_image2d_msaa_t, Loc,
-                                     PrevSpec, DiagID, Policy);
-      break;
-    case tok::kw_image2d_msaa_depth_t:
-      isInvalid = DS.SetTypeSpecType(DeclSpec::TST_image2d_msaa_depth_t, Loc,
-                                     PrevSpec, DiagID, Policy);
-      break;
-    case tok::kw_image2d_array_msaa_depth_t:
-      isInvalid = DS.SetTypeSpecType(DeclSpec::TST_image2d_array_msaa_depth_t, Loc,
-                                     PrevSpec, DiagID, Policy);
-      break;
-    case tok::kw_image2d_array_msaa_t:
-      isInvalid = DS.SetTypeSpecType(DeclSpec::TST_image2d_array_msaa_t, Loc,
-                                     PrevSpec, DiagID, Policy);
-      break;
-    case tok::kw_image2d_array_depth_t:
-      isInvalid = DS.SetTypeSpecType(DeclSpec::TST_image2d_array_depth_t, Loc,
-                                     PrevSpec, DiagID, Policy);
-      break;
     case tok::kw_sampler_t:
       isInvalid = DS.SetTypeSpecType(DeclSpec::TST_sampler_t, Loc,
                                      PrevSpec, DiagID, Policy);
@@ -3285,6 +3236,12 @@ void Parser::ParseDeclarationSpecifiers(DeclSpec &DS,
       }
       isInvalid = DS.SetTypePipe(true, Loc, PrevSpec, DiagID, Policy);
       break;
+#define GENERIC_IMAGE_TYPE(ImgType, Id) \
+    case tok::kw_##ImgType##_t: \
+      isInvalid = DS.SetTypeSpecType(DeclSpec::TST_##ImgType##_t, Loc, PrevSpec, \
+                                     DiagID, Policy); \
+      break;
+#include "clang/Basic/OpenCLImageTypes.def"
     case tok::kw___unknown_anytype:
       isInvalid = DS.SetTypeSpecType(TST_unknown_anytype, Loc,
                                      PrevSpec, DiagID, Policy);
@@ -4170,20 +4127,10 @@ bool Parser::isKnownToBeTypeSpecifier(const Token &Tok) const {
   case tok::kw__Decimal64:
   case tok::kw__Decimal128:
   case tok::kw___vector:
+#define GENERIC_IMAGE_TYPE(ImgType, Id) case tok::kw_##ImgType##_t:
+#include "clang/Basic/OpenCLImageTypes.def"
 
     // OpenCL specific types:
-  case tok::kw_image1d_t:
-  case tok::kw_image1d_array_t:
-  case tok::kw_image1d_buffer_t:
-  case tok::kw_image2d_t:
-  case tok::kw_image2d_array_t:
-  case tok::kw_image3d_t:
-  case tok::kw_image2d_depth_t:
-  case tok::kw_image2d_msaa_t:
-  case tok::kw_image2d_msaa_depth_t:
-  case tok::kw_image2d_array_msaa_depth_t:
-  case tok::kw_image2d_array_msaa_t:
-  case tok::kw_image2d_array_depth_t:
   case tok::kw_sampler_t:
   case tok::kw_event_t:
   case tok::kw_queue_t:
@@ -4261,19 +4208,9 @@ bool Parser::isTypeSpecifierQualifier() {
   case tok::kw__Decimal128:
   case tok::kw___vector:
 
-    // OpenCL specific types:
-  case tok::kw_image1d_t:
-  case tok::kw_image1d_array_t:
-  case tok::kw_image1d_buffer_t:
-  case tok::kw_image2d_t:
-  case tok::kw_image2d_array_t:
-  case tok::kw_image3d_t:
-  case tok::kw_image2d_depth_t:
-  case tok::kw_image2d_msaa_t:
-  case tok::kw_image2d_msaa_depth_t:
-  case tok::kw_image2d_array_msaa_depth_t:
-  case tok::kw_image2d_array_msaa_t:
-  case tok::kw_image2d_array_depth_t:
+  // OpenCL specific types:
+#define GENERIC_IMAGE_TYPE(ImgType, Id) case tok::kw_##ImgType##_t:
+#include "clang/Basic/OpenCLImageTypes.def"
   case tok::kw_sampler_t:
   case tok::kw_event_t:
   case tok::kw_queue_t:
@@ -4430,24 +4367,22 @@ bool Parser::isDeclarationSpecifier(bool DisambiguatingWithExpression) {
   case tok::kw__Decimal128:
   case tok::kw___vector:
 
-    // OpenCL specific types:
-  case tok::kw_image1d_t:
-  case tok::kw_image1d_array_t:
-  case tok::kw_image1d_buffer_t:
-  case tok::kw_image2d_t:
-  case tok::kw_image2d_array_t:
-  case tok::kw_image3d_t:
-  case tok::kw_image2d_depth_t:
-  case tok::kw_image2d_msaa_t:
-  case tok::kw_image2d_msaa_depth_t:
-  case tok::kw_image2d_array_msaa_depth_t:
-  case tok::kw_image2d_array_msaa_t:
-  case tok::kw_image2d_array_depth_t:
+  // OpenCL specific types:
+#define GENERIC_IMAGE_TYPE(ImgType, Id) case tok::kw_##ImgType##_t:
+#include "clang/Basic/OpenCLImageTypes.def"
   case tok::kw_sampler_t:
   case tok::kw_event_t:
   case tok::kw_queue_t:
   case tok::kw_clk_event_t:
   case tok::kw_reserve_id_t:
+  case tok::kw___private:
+  case tok::kw___local:
+  case tok::kw___global:
+  case tok::kw___constant:
+  case tok::kw___generic:
+  case tok::kw___read_only:
+  case tok::kw___read_write:
+  case tok::kw___write_only:
 
     // struct-or-union-specifier (C99) or class-specifier (C++)
   case tok::kw_class:
@@ -4514,15 +4449,6 @@ bool Parser::isDeclarationSpecifier(bool DisambiguatingWithExpression) {
   case tok::kw___forceinline:
   case tok::kw___pascal:
   case tok::kw___unaligned:
-
-  case tok::kw___private:
-  case tok::kw___local:
-  case tok::kw___global:
-  case tok::kw___constant:
-  case tok::kw___generic:
-  case tok::kw___read_only:
-  case tok::kw___read_write:
-  case tok::kw___write_only:
 
     return true;
   }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1107,23 +1107,14 @@ ExprResult Parser::ParseCastExpression(bool isUnaryExpression,
   case tok::kw_void:
   case tok::kw_typename:
   case tok::kw_typeof:
-  case tok::kw_image1d_t:
-  case tok::kw_image1d_array_t:
-  case tok::kw_image1d_buffer_t:
-  case tok::kw_image2d_t:
-  case tok::kw_image2d_array_t:
-  case tok::kw_image2d_depth_t:
-  case tok::kw_image2d_array_depth_t:
-  case tok::kw_image2d_msaa_t:
-  case tok::kw_image2d_array_msaa_t:
-  case tok::kw_image2d_msaa_depth_t:
-  case tok::kw_image2d_array_msaa_depth_t:
-  case tok::kw_image3d_t:
   case tok::kw_sampler_t:
   case tok::kw_event_t:
   case tok::kw_queue_t:
   case tok::kw_clk_event_t:
-  case tok::kw___vector: {
+  case tok::kw___vector:
+#define GENERIC_IMAGE_TYPE(ImgType, Id) case tok::kw_##ImgType##_t:
+#include "clang/Basic/OpenCLImageTypes.def"
+  {
     if (!getLangOpts().CPlusPlus) {
       Diag(Tok, diag::err_expected_expression);
       return ExprError();

--- a/lib/Parse/ParseTentative.cpp
+++ b/lib/Parse/ParseTentative.cpp
@@ -994,18 +994,8 @@ Parser::isExpressionOrTypeSpecifierSimple(tok::TokenKind Kind) {
   case tok::kw___pixel:
   case tok::kw___bool:
   case tok::kw__Atomic:
-  case tok::kw_image1d_t:
-  case tok::kw_image1d_array_t:
-  case tok::kw_image1d_buffer_t:
-  case tok::kw_image2d_t:
-  case tok::kw_image2d_array_t:
-  case tok::kw_image2d_depth_t:
-  case tok::kw_image2d_array_depth_t:
-  case tok::kw_image2d_msaa_t:
-  case tok::kw_image2d_array_msaa_t:
-  case tok::kw_image2d_msaa_depth_t:
-  case tok::kw_image2d_array_msaa_depth_t:
-  case tok::kw_image3d_t:
+#define GENERIC_IMAGE_TYPE(ImgType, Id) case tok::kw_##ImgType##_t:
+#include "clang/Basic/OpenCLImageTypes.def"
   case tok::kw_sampler_t:
   case tok::kw_event_t:
   case tok::kw_queue_t:

--- a/lib/Sema/DeclSpec.cpp
+++ b/lib/Sema/DeclSpec.cpp
@@ -310,18 +310,8 @@ bool Declarator::isDeclarationOfFunction() const {
     case TST_unspecified:
     case TST_void:
     case TST_wchar:
-    case TST_image1d_t:
-    case TST_image1d_array_t:
-    case TST_image1d_buffer_t:
-    case TST_image2d_t:
-    case TST_image2d_array_t:
-    case TST_image3d_t:
-    case TST_image2d_depth_t:
-    case TST_image2d_msaa_t:
-    case TST_image2d_msaa_depth_t:
-    case TST_image2d_array_msaa_depth_t:
-    case TST_image2d_array_msaa_t:
-    case TST_image2d_array_depth_t:
+#define GENERIC_IMAGE_TYPE(ImgType, Id) case TST_##ImgType##_t:
+#include "clang/Basic/OpenCLImageTypes.def"
     case TST_sampler_t:
     case TST_event_t:
     case TST_queue_t:
@@ -492,18 +482,10 @@ const char *DeclSpec::getSpecifierName(DeclSpec::TST T,
   case DeclSpec::TST_underlyingType: return "__underlying_type";
   case DeclSpec::TST_unknown_anytype: return "__unknown_anytype";
   case DeclSpec::TST_atomic: return "_Atomic";
-  case DeclSpec::TST_image1d_t:   return "image1d_t";
-  case DeclSpec::TST_image1d_array_t: return "image1d_array_t";
-  case DeclSpec::TST_image1d_buffer_t: return "image1d_buffer_t";
-  case DeclSpec::TST_image2d_t:   return "image2d_t";
-  case DeclSpec::TST_image2d_array_t: return "image2d_array_t";
-  case DeclSpec::TST_image3d_t:   return "image3d_t";
-  case DeclSpec::TST_image2d_depth_t: return "image2d_depth_t";
-  case DeclSpec::TST_image2d_msaa_t: return "image2d_msaa_t";
-  case DeclSpec::TST_image2d_msaa_depth_t: return "image2d_msaa_depth_t";
-  case DeclSpec::TST_image2d_array_msaa_depth_t: return "image2d_array_msaa_depth_t";
-  case DeclSpec::TST_image2d_array_msaa_t: return "image2d_array_msaa_t";
-  case DeclSpec::TST_image2d_array_depth_t: return "image2d_array_depth_t";
+#define GENERIC_IMAGE_TYPE(ImgType, Id) \
+  case DeclSpec::TST_##ImgType##_t: \
+    return #ImgType "_t";
+#include "clang/Basic/OpenCLImageTypes.def"
   case DeclSpec::TST_sampler_t:   return "sampler_t";
   case DeclSpec::TST_event_t:     return "event_t";
   case DeclSpec::TST_queue_t:     return "queue_t";

--- a/lib/Sema/Sema.cpp
+++ b/lib/Sema/Sema.cpp
@@ -206,12 +206,6 @@ void Sema::Initialize() {
 
   // Initialize predefined OpenCL types.
   if (PP.getLangOpts().OpenCL) {
-    addImplicitTypedef("image1d_t", Context.OCLImage1dTy);
-    addImplicitTypedef("image1d_array_t", Context.OCLImage1dArrayTy);
-    addImplicitTypedef("image1d_buffer_t", Context.OCLImage1dBufferTy);
-    addImplicitTypedef("image2d_t", Context.OCLImage2dTy);
-    addImplicitTypedef("image2d_array_t", Context.OCLImage2dArrayTy);
-    addImplicitTypedef("image3d_t", Context.OCLImage3dTy);
     addImplicitTypedef("sampler_t", Context.OCLSamplerTy);
     addImplicitTypedef("event_t", Context.OCLEventTy);
     if (getLangOpts().OpenCLVersion >= 200) {

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -4648,6 +4648,9 @@ static bool isPlaceholderToRemoveAsArg(QualType type) {
 
   switch (placeholder->getKind()) {
   // Ignore all the non-placeholder types.
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  case BuiltinType::Id:
+#include "clang/Basic/OpenCLImageTypes.def"
 #define PLACEHOLDER_TYPE(ID, SINGLETON_ID)
 #define BUILTIN_TYPE(ID, SINGLETON_ID) case BuiltinType::ID:
 #include "clang/AST/BuiltinTypes.def"
@@ -14251,8 +14254,10 @@ ExprResult Sema::CheckPlaceholderExpr(Expr *E) {
   }
 
   // Everything else should be impossible.
-#define BUILTIN_TYPE(Id, SingletonId) \
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
   case BuiltinType::Id:
+#include "clang/Basic/OpenCLImageTypes.def"
+#define BUILTIN_TYPE(Id, SingletonId) case BuiltinType::Id:
 #define PLACEHOLDER_TYPE(Id, SingletonId)
 #include "clang/AST/BuiltinTypes.def"
     break;

--- a/lib/Sema/SemaTemplateVariadic.cpp
+++ b/lib/Sema/SemaTemplateVariadic.cpp
@@ -743,19 +743,9 @@ bool Sema::containsUnexpandedParameterPacks(Declarator &D) {
   case TST_class:
   case TST_auto:
   case TST_decltype_auto:
+#define GENERIC_IMAGE_TYPE(ImgType, Id) case TST_##ImgType##_t:
+#include "clang/Basic/OpenCLImageTypes.def"
   case TST_unknown_anytype:
-  case TST_image1d_t:
-  case TST_image1d_array_t:
-  case TST_image1d_buffer_t:
-  case TST_image2d_t:
-  case TST_image2d_array_t:
-  case TST_image2d_depth_t:
-  case TST_image2d_array_depth_t:
-  case TST_image2d_msaa_t:
-  case TST_image2d_array_msaa_t:
-  case TST_image2d_msaa_depth_t:
-  case TST_image2d_array_msaa_depth_t:
-  case TST_image3d_t:
   case TST_sampler_t:
   case TST_event_t:
   case TST_queue_t:

--- a/lib/Serialization/ASTCommon.cpp
+++ b/lib/Serialization/ASTCommon.cpp
@@ -62,18 +62,11 @@ serialization::TypeIdxFromBuiltin(const BuiltinType *BT) {
   case BuiltinType::ObjCId:     ID = PREDEF_TYPE_OBJC_ID;       break;
   case BuiltinType::ObjCClass:  ID = PREDEF_TYPE_OBJC_CLASS;    break;
   case BuiltinType::ObjCSel:    ID = PREDEF_TYPE_OBJC_SEL;      break;
-  case BuiltinType::OCLImage1d:       ID = PREDEF_TYPE_IMAGE1D_ID;      break;
-  case BuiltinType::OCLImage1dArray:  ID = PREDEF_TYPE_IMAGE1D_ARR_ID;  break;
-  case BuiltinType::OCLImage1dBuffer: ID = PREDEF_TYPE_IMAGE1D_BUFF_ID; break;
-  case BuiltinType::OCLImage2d:       ID = PREDEF_TYPE_IMAGE2D_ID;      break;
-  case BuiltinType::OCLImage2dArray:  ID = PREDEF_TYPE_IMAGE2D_ARR_ID;  break;
-  case BuiltinType::OCLImage3d:       ID = PREDEF_TYPE_IMAGE3D_ID;      break;
-  case BuiltinType::OCLImage2dDepth:  ID = PREDEF_TYPE_IMAGE2DDepth_ID; break;
-  case BuiltinType::OCLImage2dMSAA:   ID = PREDEF_TYPE_IMAGE2DMSAA_ID;  break;
-  case BuiltinType::OCLImage2dMSAADepth: ID = PREDEF_TYPE_IMAGE2DMSAADepth_ID; break;
-  case BuiltinType::OCLImage2dArrayMSAADepth: ID = PREDEF_TYPE_IMAGE2DArrayMSAADepth_ID; break;
-  case BuiltinType::OCLImage2dArrayMSAA: ID = PREDEF_TYPE_IMAGE2DArrayMSAA_ID; break;
-  case BuiltinType::OCLImage2dArrayDepth: ID = PREDEF_TYPE_IMAGE2DArrayDepth_ID; break;
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  case BuiltinType::Id: \
+    ID = PREDEF_TYPE_##Id##_ID; \
+    break;
+#include "clang/Basic/OpenCLImageTypes.def"
   case BuiltinType::OCLSampler:       ID = PREDEF_TYPE_SAMPLER_ID;      break;
   case BuiltinType::OCLEvent:         ID = PREDEF_TYPE_EVENT_ID;        break;
   case BuiltinType::OCLQueue:         ID = PREDEF_TYPE_QUEUE_ID;        break;

--- a/lib/Serialization/ASTReader.cpp
+++ b/lib/Serialization/ASTReader.cpp
@@ -5962,19 +5962,11 @@ QualType ASTReader::GetType(TypeID ID) {
     case PREDEF_TYPE_OBJC_ID:       T = Context.ObjCBuiltinIdTy;    break;
     case PREDEF_TYPE_OBJC_CLASS:    T = Context.ObjCBuiltinClassTy; break;
     case PREDEF_TYPE_OBJC_SEL:      T = Context.ObjCBuiltinSelTy;   break;
-    case PREDEF_TYPE_IMAGE1D_ID:    T = Context.OCLImage1dTy;       break;
-    case PREDEF_TYPE_IMAGE1D_ARR_ID: T = Context.OCLImage1dArrayTy; break;
-    case PREDEF_TYPE_IMAGE1D_BUFF_ID: T = Context.OCLImage1dBufferTy; break;
-    case PREDEF_TYPE_IMAGE2D_ID:    T = Context.OCLImage2dTy;       break;
-    case PREDEF_TYPE_IMAGE2D_ARR_ID: T = Context.OCLImage2dArrayTy; break;
-    case PREDEF_TYPE_IMAGE3D_ID:    T = Context.OCLImage3dTy;       break;
-    case PREDEF_TYPE_IMAGE2DDepth_ID:          T = Context.OCLImage2dDepthTy; break;
-    case PREDEF_TYPE_IMAGE2DMSAA_ID:           T = Context.OCLImage2dMSAATy; break;
-    case PREDEF_TYPE_IMAGE2DMSAADepth_ID:      T = Context.OCLImage2dMSAADepthTy; break;
-    case PREDEF_TYPE_IMAGE2DArrayMSAADepth_ID: T = Context.OCLImage2dArrayMSAADepthTy; break;
-    case PREDEF_TYPE_IMAGE2DArrayMSAA_ID:      T = Context.OCLImage2dArrayMSAATy; break;
-    case PREDEF_TYPE_IMAGE2DArrayDepth_ID:     T = Context.OCLImage2dArrayDepthTy; break;
-
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+    case PREDEF_TYPE_##Id##_ID: \
+      T = Context.SingletonId; \
+      break;
+#include "clang/Basic/OpenCLImageTypes.def"
     case PREDEF_TYPE_SAMPLER_ID:    T = Context.OCLSamplerTy;       break;
     case PREDEF_TYPE_EVENT_ID:      T = Context.OCLEventTy;         break;
     case PREDEF_TYPE_QUEUE_ID:      T = Context.OCLQueueTy;         break;

--- a/test/CodeGenOpenCL/images.cl
+++ b/test/CodeGenOpenCL/images.cl
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 %s -triple x86_64-unknown-linux-gnu -O0 -emit-llvm -o - | FileCheck %s
+
+__attribute__((overloadable)) void read_image(read_only image1d_t img_ro);
+__attribute__((overloadable)) void read_image(write_only image1d_t img_wo);
+
+kernel void test_read_image(read_only image1d_t img_ro, write_only image1d_t img_wo) {
+  // CHECK: call void @_Z10read_image14ocl_image1d_ro(%opencl.image1d_ro_t* %{{[0-9]+}})
+  read_image(img_ro);
+  // CHECK: call void @_Z10read_image14ocl_image1d_wo(%opencl.image1d_wo_t* %{{[0-9]+}})
+  read_image(img_wo);
+}

--- a/test/CodeGenOpenCL/opencl_types.cl
+++ b/test/CodeGenOpenCL/opencl_types.cl
@@ -6,36 +6,36 @@ constant sampler_t glb_smp = 7;
 // CHECK-SAMPLER-TYPE: constant %opencl.sampler_t { i32 7 }
 
 void fnc1(image1d_t img) {}
-// CHECK: @fnc1(%opencl.image1d_t {{.*}}*
+// CHECK: @fnc1(%opencl.image1d_ro_t {{.*}}*
 
 void fnc1arr(image1d_array_t img) {}
-// CHECK: @fnc1arr(%opencl.image1d_array_t {{.*}}*
+// CHECK: @fnc1arr(%opencl.image1d_array_ro_t {{.*}}*
 
 void fnc1buff(image1d_buffer_t img) {}
-// CHECK: @fnc1buff(%opencl.image1d_buffer_t {{.*}}*
+// CHECK: @fnc1buff(%opencl.image1d_buffer_ro_t {{.*}}*
 
 void fnc2(image2d_t img) {}
-// CHECK: @fnc2(%opencl.image2d_t {{.*}}*
+// CHECK: @fnc2(%opencl.image2d_ro_t {{.*}}*
 
 void fnc2arr(image2d_array_t img) {}
-// CHECK: @fnc2arr(%opencl.image2d_array_t {{.*}}*
+// CHECK: @fnc2arr(%opencl.image2d_array_ro_t {{.*}}*
 
 void fnc3(image3d_t img) {}
-// CHECK: @fnc3(%opencl.image3d_t {{.*}}*
+// CHECK: @fnc3(%opencl.image3d_ro_t {{.*}}*
 
 void fnc4smp(sampler_t s) {}
 // CHECK: define spir_func void @fnc4smp(i32
 // CHECK-SAMPLER-TYPE: define spir_func void @fnc4smp(%opencl.sampler_t* byval
 
 kernel void foo(image1d_t img) {
-// CHECK: define spir_kernel void @foo(%opencl.image1d_t {{.*}}*
-// CHECK-SAMPLER-TYPE: define spir_kernel void @foo(%opencl.image1d_t {{.*}}*
+// CHECK: define spir_kernel void @foo(%opencl.image1d_ro_t {{.*}}*
+// CHECK-SAMPLER-TYPE: define spir_kernel void @foo(%opencl.image1d_ro_t {{.*}}*
 
   sampler_t smp = 5;
   // CHECK: alloca i32
   // CHECK-SAMPLER-TYPE: [[SMP_PTR:%[A-Za-z0-9_\.]+]] = alloca %opencl.sampler_t
 
-	event_t evt;
+  event_t evt;
   // CHECK: alloca %opencl.event_t*
 
   fnc4smp(smp);
@@ -52,4 +52,4 @@ kernel void foo(image1d_t img) {
 }
 
 void __attribute__((overloadable)) bad1(image1d_t b, image2d_t c, image2d_t d) {}
-// CHECK-LABEL: @{{_Z4bad111ocl_image1d11ocl_image2d11ocl_image2d|"\\01\?bad1@@YAXPAUocl_image1d@@PAUocl_image2d@@1@Z"}}
+// CHECK-LABEL: @{{_Z4bad114ocl_image1d_ro14ocl_image2d_ro14ocl_image2d_ro|"\\01\?bad1@@\$\$J0YAXPAUocl_image1d_ro@@PAUocl_image2d_ro@@1@Z"}}

--- a/test/OpenCL/OpenCL20/Pipes/pipe_typedefs.cl
+++ b/test/OpenCL/OpenCL20/Pipes/pipe_typedefs.cl
@@ -7,4 +7,4 @@ kernel void f(RImage img, IPipe p){
 
 // CHECK-DAG: [[MDNODE:![0-9]+]] = !{!"kernel_arg_access_qual", !"read_only", !"read_only"}
 // CHECK-DAG: [[MDNODE:![0-9]+]] = !{!"kernel_arg_type_qual", !"", !"pipe"}
-// CHECK-DAG: [[MDNODE:![0-9]+]] = !{!"kernel_arg_base_type", !"image2d_t", !"int"}
+// CHECK-DAG: [[MDNODE:![0-9]+]] = !{!"kernel_arg_base_type", !"__read_only image2d_t", !"int"}

--- a/test/OpenCL/Restrictions/images.cl
+++ b/test/OpenCL/Restrictions/images.cl
@@ -1,30 +1,16 @@
 // RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only
 
-void myWrite(write_only image2d_t);
-void myRead (read_only image2d_t);
+// TODO: remove the note from diagnostics???
+void myWrite(write_only image2d_t); // expected-note {{passing argument to parameter here}}
+void myRead (read_only image2d_t); // expected-note {{passing argument to parameter here}}
 void myReadWrite (read_write image2d_t);
 void myIndifferent (image2d_t);
 
 
 kernel void k1 (read_only image2d_t img) {
-  myWrite(img); // expected-error {{passing ''read_only'' to ''write_only'' mismatch access qualifiers}}
+  myWrite(img); // expected-error {{passing '__read_only image2d_t' to parameter of incompatible type '__write_only image2d_t'}}
 }
 
 kernel void k2 (write_only image2d_t img) {
-  myRead(img); // expected-error {{passing ''write_only'' to ''read_only'' mismatch access qualifiers}}
-}
-
-// Should be all OK.
-kernel void k3 (read_write image2d_t img) {
-  myRead(img);  // read_write > read_only
-  myWrite(img); // read_write > write_only
-  myReadWrite(img); //read_write = read_write
-}
-
-// Legal to path everything to an 'indifferent' function.
-kernel void k4(read_write image2d_t i1, read_only image2d_t i2,
-               write_only image2d_t i3) {
-  myIndifferent(i1);
-  myIndifferent(i2);
-  myIndifferent(i3);
+  myRead(img); // expected-error {{'__write_only image2d_t' to parameter of incompatible type '__read_only image2d_t'}}
 }

--- a/test/SemaOpenCL/images.cl
+++ b/test/SemaOpenCL/images.cl
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only
+
+void img2d_ro(__read_only image2d_t img) {} // expected-note{{passing argument to parameter 'img' here}} expected-note{{passing argument to parameter 'img' here}}
+
+void imgage_access_test(image2d_t img2dro, write_only image2d_t img2dwo, image3d_t img3dro) {
+  img2d_ro(img2dro);
+  img2d_ro(img2dwo); // expected-error{{passing '__write_only image2d_t' to parameter of incompatible type '__read_only image2d_t'}}
+  img2d_ro(img3dro); // expected-error{{passing '__read_only image3d_t' to parameter of incompatible type '__read_only image2d_t'}}
+}

--- a/test/SemaOpenCL/invalid-kernel-parameters.cl
+++ b/test/SemaOpenCL/invalid-kernel-parameters.cl
@@ -24,7 +24,10 @@ kernel void bool_in_struct_arg(ContainsBool x) { } // expected-error{{'ContainsB
 
 typedef struct FooImage2D // expected-note{{within field of type 'FooImage2D' declared here}}
 {
-  image2d_t imageField; // expected-note{{field of illegal type 'image2d_t' declared here}}
+  // TODO: Clean up needed - we don't really need to check for image, event, etc
+  // as a note here any longer.
+  // They are diagnosed as an error for all struct fields (OpenCL v1.2 s6.9b,r).
+  image2d_t imageField; // expected-note{{field of illegal type '__read_only image2d_t' declared here}}
 } FooImage2D;
 
 kernel void image_in_struct_arg(FooImage2D arg) { } // expected-error{{struct kernel parameters may not contain pointers}}

--- a/tools/libclang/CIndex.cpp
+++ b/tools/libclang/CIndex.cpp
@@ -1419,18 +1419,9 @@ bool CursorVisitor::VisitBuiltinTypeLoc(BuiltinTypeLoc TL) {
   case BuiltinType::Void:
   case BuiltinType::NullPtr:
   case BuiltinType::Dependent:
-  case BuiltinType::OCLImage1d:
-  case BuiltinType::OCLImage1dArray:
-  case BuiltinType::OCLImage1dBuffer:
-  case BuiltinType::OCLImage2d:
-  case BuiltinType::OCLImage2dArray:
-  case BuiltinType::OCLImage3d:
-  case BuiltinType::OCLImage2dDepth:
-  case BuiltinType::OCLImage2dMSAA:
-  case BuiltinType::OCLImage2dMSAADepth:
-  case BuiltinType::OCLImage2dArrayMSAADepth:
-  case BuiltinType::OCLImage2dArrayMSAA:
-  case BuiltinType::OCLImage2dArrayDepth:
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+  case BuiltinType::Id:
+#include "clang/Basic/OpenCLImageTypes.def"
   case BuiltinType::OCLSampler:
   case BuiltinType::OCLEvent:
   case BuiltinType::OCLQueue:


### PR DESCRIPTION
I. Current implementation of images is not conformant to spec in the following points:
1. It makes no distinction with respect to access qualifiers and therefore allows to use images with different access type interchangeably. The following code would compile just fine:
   
   ```
   void write_image(write_only image2d_t img);
   kernel void foo(read_only image2d_t img) { write_image(img); } // Accepted code
   ```
   
    which is disallowed according to s6.13.14.
2. It discards access qualifier on generated code, which leads to generated code for the above example:
   
   ```
   call void @write_image(%opencl.image2d_t* %img);
   ```
   
    In OpenCL2.0 however we can have different calls into write_image with read_only and wite_only images.
    Also generally following compiler steps have no easy way to take different path depending on the image access: linking to the right implementation of image types, performing IR opts and backend codegen differently.
3. Image types are language keywords and can't be redeclared s6.1.9, which can happen currently as they are just typedef names.
4. Default access qualifier read_only is to be added if not provided explicitly.

II. This patch corrects the above points as follows:
1. All images are encapsulated into a separate .def file that is inserted in different points where image handling is required. This avoid a lot of code repetition as all images are handled the same way in the code with no distinction of their exact type.
2. The Cartesian product of image types and image access qualifiers is added to the builtin types. This simplifies a lot handling of access type mismatch as no operations are allowed by default on distinct Builtin types. Also spec intended access qualifier as special type qualifier that are combined with an image type to form a distinct type (see statement above - images can't be created w/o access qualifiers).
3. Improves testing of images in Clang.
