### PR TITLE
Targets: Set native integer types for SPIRxxTargetInfo

### DIFF
--- a/lib/Basic/Targets.cpp
+++ b/lib/Basic/Targets.cpp
@@ -6367,7 +6367,8 @@ namespace {
       PtrDiffType = IntPtrType = TargetInfo::SignedInt;
       DescriptionString
         = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-"
-          "v96:128-v192:256-v256:256-v512:512-v1024:1024";
+          "v96:128-v192:256-v256:256-v512:512-v1024:1024"
+          "-n8:16:32:64";
     }
     void getTargetDefines(const LangOptions &Opts,
                           MacroBuilder &Builder) const override {
@@ -6382,7 +6383,8 @@ namespace {
       SizeType     = TargetInfo::UnsignedLong;
       PtrDiffType = IntPtrType = TargetInfo::SignedLong;
       DescriptionString = "e-i64:64-v16:16-v24:32-v32:32-v48:64-"
-                          "v96:128-v192:256-v256:256-v512:512-v1024:1024";
+                          "v96:128-v192:256-v256:256-v512:512-v1024:1024"
+                          "-n8:16:32:64";
     }
     void getTargetDefines(const LangOptions &Opts,
                           MacroBuilder &Builder) const override {


### PR DESCRIPTION
Without those native integer types, `LegalIntWidths` is empty, resulting in `DataLayout::getSmallestLegalIntType()` returning a null pointer.

Fixes: KhronosGroup/SPIRV-LLVM#42
