### PR TITLE
This additional patch makes it possible to use the metarenamer (llvm …

### DIFF
--- a/LlvmTransforms_MetaRenamer_KeepFunctionNames_ForSpirObfuscation.patch
+++ b/LlvmTransforms_MetaRenamer_KeepFunctionNames_ForSpirObfuscation.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/Transforms/Utils/MetaRenamer.cpp b/lib/Transforms/Utils/MetaRenamer.cpp
+index 233bc12..5819856 100644
+--- a/lib/Transforms/Utils/MetaRenamer.cpp
++++ b/lib/Transforms/Utils/MetaRenamer.cpp
+@@ -96,7 +96,7 @@ namespace {
+       // Rename all functions
+       for (Module::iterator FI = M.begin(), FE = M.end();
+            FI != FE; ++FI) {
+-        FI->setName(metaNames[prng.rand() % array_lengthof(metaNames)]);
++        // FI->setName(metaNames[prng.rand() % array_lengthof(metaNames)]);
+         runOnFunction(*FI);
+       }
+       return true;

--- a/LlvmTransforms_MetaRenamer_KeepFunctionNames_ForSpirObfuscation.patch
+++ b/LlvmTransforms_MetaRenamer_KeepFunctionNames_ForSpirObfuscation.patch
@@ -1,13 +1,16 @@
 diff --git a/lib/Transforms/Utils/MetaRenamer.cpp b/lib/Transforms/Utils/MetaRenamer.cpp
-index 233bc12..5819856 100644
+index 233bc12..c53aa2f 100644
 --- a/lib/Transforms/Utils/MetaRenamer.cpp
 +++ b/lib/Transforms/Utils/MetaRenamer.cpp
-@@ -96,7 +96,7 @@ namespace {
+@@ -96,7 +96,10 @@ namespace {
        // Rename all functions
        for (Module::iterator FI = M.begin(), FE = M.end();
             FI != FE; ++FI) {
 -        FI->setName(metaNames[prng.rand() % array_lengthof(metaNames)]);
-+        // FI->setName(metaNames[prng.rand() % array_lengthof(metaNames)]);
++        if ((FI->getCallingConv() == llvm::CallingConv::SPIR_FUNC && !FI->isDeclaration())
++            || (FI->getCallingConv() != llvm::CallingConv::SPIR_FUNC && FI->getCallingConv() != llvm::CallingConv::SPIR_KERNEL))
++          FI->setName(metaNames[prng.rand() & array_lengthof(metaNames)]);
++
          runOnFunction(*FI);
        }
        return true;


### PR DESCRIPTION
…transform pass) for additional spir obfuscation since it does not change function names.

I used this to obfuscate spir binaries since I realized that the format keeps most of the variable and argument names. The original implementation of the metarenamer pass also changes the function names which makes it impossible to use it in this use case.

What do you think about his? Is there a better way to implement this?
