### PR TITLE
[OpenCL] Fix access qualifiers metadata for kernel arguments with typ…

### DIFF
--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -3574,6 +3574,22 @@ static void handleGNUInlineAttr(Sema &S, Decl *D, const AttributeList &Attr) {
   D->addAttr(::new (S.Context) GNUInlineAttr(Attr.getRange(), S.Context));
 }
 
+static void handleOpenCLImageAccessAttr(Sema &S, Decl *D, const AttributeList &Attr){
+  assert(!Attr.isInvalid());
+
+  Expr *E = Attr.getArg(0);
+  llvm::APSInt ArgNum(32);
+  if (E->isTypeDependent() || E->isValueDependent() ||
+      !E->isIntegerConstantExpr(ArgNum, S.Context)) {
+    S.Diag(Attr.getLoc(), diag::err_attribute_argument_not_int)
+      << Attr.getName()->getName() << E->getSourceRange();
+    return;
+  }
+
+  D->addAttr(::new (S.Context) OpenCLImageAccessAttr(
+    Attr.getRange(), S.Context, ArgNum.getZExtValue()));
+}
+
 static void handleCallConvAttr(Sema &S, Decl *D, const AttributeList &Attr) {
   if (hasDeclarator(D)) return;
 
@@ -4288,7 +4304,6 @@ static void ProcessInheritableDeclAttr(Sema &S, Scope *scope, Decl *D,
     case AttributeList::AT_IBOutletCollection:
       handleIBOutletCollection(S, D, Attr); break;
   case AttributeList::AT_AddressSpace:
-  case AttributeList::AT_OpenCLImageAccess:
   case AttributeList::AT_ObjCGC:
   case AttributeList::AT_VectorSize:
   case AttributeList::AT_NeonVectorType:
@@ -4452,6 +4467,9 @@ static void ProcessInheritableDeclAttr(Sema &S, Scope *scope, Decl *D,
     break;
   case AttributeList::AT_VecTypeHint:
     handleVecTypeHint(S, D, Attr);
+    break;
+  case AttributeList::AT_OpenCLImageAccess:
+    handleOpenCLImageAccessAttr(S, D, Attr);
     break;
 
   // Microsoft attributes:

--- a/test/CodeGenOpenCL/kernel-arg-info.cl
+++ b/test/CodeGenOpenCL/kernel-arg-info.cl
@@ -5,3 +5,14 @@ kernel void foo(int *X, int Y, int anotherArg) {
 }
 
 // CHECK: metadata !{metadata !"kernel_arg_name", metadata !"X", metadata !"Y", metadata !"anotherArg"}
+
+typedef read_only  image1d_t ROImage;
+typedef write_only image1d_t WOImage;
+typedef read_write image1d_t RWImage;
+kernel void foo2(ROImage ro, WOImage wo, RWImage rw) {
+}
+// CHECK: @foo2
+// CHECK: !{metadata !"kernel_arg_access_qual", metadata !"read_only", metadata !"write_only", metadata !"read_write"}
+// CHECK: !{metadata !"kernel_arg_type", metadata !"ROImage", metadata !"WOImage", metadata !"RWImage"}
+// CHECK: !{metadata !"kernel_arg_base_type", metadata !"image1d_t", metadata !"image1d_t", metadata !"image1d_t"}
+// CHECK: !{metadata !"kernel_arg_name", metadata !"ro", metadata !"wo", metadata !"rw"}


### PR DESCRIPTION
…edef

Porting the fix from the trunk: https://reviews.llvm.org/D35420
Added handling of OpenCL image access attributes