### PR TITLE
Remove reference to Bugzilla when reporting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ command lines:
 Reporting issues
 ----------------
 
-Bugs/feature requests can be filed via [github](https://github.com/KhronosGroup/SPIR/issues) or [Khronos Bugzilla](https://www.khronos.org/bugzilla/) bug tracker.
+Bugs/feature requests can be filed via [github](https://github.com/KhronosGroup/SPIR/issues).


### PR DESCRIPTION
Khronos Bugzilla is no longer used for reporting issues. 